### PR TITLE
Add tests for token api

### DIFF
--- a/__test__/integration/servicing_api.spec.ts
+++ b/__test__/integration/servicing_api.spec.ts
@@ -126,7 +126,7 @@ describe("Debt Servicing API (Integration Tests)", () => {
                         new BigNumber(-100),
                         principalToken.address,
                     ),
-                ).rejects.toThrow(/instance does not match pattern/);
+                ).rejects.toThrow(/instance does not conform to the "BigNumber" format/);
             });
         });
 

--- a/__test__/integration/signer_api.spec.ts
+++ b/__test__/integration/signer_api.spec.ts
@@ -94,7 +94,6 @@ describe("Order Signer (Unit Tests)", () => {
                 });
             });
 
-            // TODO: Check more precisely for numbers being of type BigNumber
             describe("malformed principal amount", () => {
                 let debtOrderMalformedPrincipal: any = Object.assign({}, debtOrder);
                 debtOrderMalformedPrincipal.principalAmount = 14;

--- a/__test__/integration/signer_api.spec.ts
+++ b/__test__/integration/signer_api.spec.ts
@@ -95,15 +95,16 @@ describe("Order Signer (Unit Tests)", () => {
             });
 
             // TODO: Check more precisely for numbers being of type BigNumber
-            // describe("malformed principal amount", () => {
-            //     let debtOrderMalformedPrincipal: any = Object.assign({}, debtOrder);
-            //     debtOrderMalformedPrincipal.principalAmount = 14;
-            //
-            //     test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
-            //         await expect(orderSigner.asDebtor(debtOrderMalformedPrincipal)).rejects
-            //             .toThrow(/\.principalAmount is not of type BigNumber/);
-            //     });
-            // });
+            describe("malformed principal amount", () => {
+                let debtOrderMalformedPrincipal: any = Object.assign({}, debtOrder);
+                debtOrderMalformedPrincipal.principalAmount = 14;
+
+                test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
+                    await expect(orderSigner.asDebtor(debtOrderMalformedPrincipal)).rejects.toThrow(
+                        /\.principalAmount does not conform to the "BigNumber" format/,
+                    );
+                });
+            });
 
             describe("missing principal token", () => {
                 let debtOrderMissingPrincipalToken = Object.assign({}, debtOrder);

--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -1,16 +1,18 @@
+import * as Web3 from "web3";
+import { BigNumber } from "bignumber.js";
+import * as ABIDecoder from "abi-decoder";
+import * as compact from "lodash.compact";
+
+import { Web3Utils } from "utils/web3_utils";
+import * as Units from "utils/units";
+
 import { ContractsAPI, TokenAPI } from "src/apis";
 import { CONTRACT_WRAPPER_ERRORS } from "src/wrappers/contract_wrappers/base_contract_wrapper";
 import { TokenAPIErrors } from "src/apis/token_api";
-import { TokenAssertionErrors } from "../../src/invariants/token";
-
-import * as Web3 from "web3";
-import { Web3Utils } from "utils/web3_utils";
+import { TokenAssertionErrors } from "src/invariants/token";
 import { DummyTokenContract, TokenTransferProxyContract } from "src/wrappers";
+
 import { ACCOUNTS } from "../accounts";
-import { BigNumber } from "bignumber.js";
-import * as ABIDecoder from "abi-decoder";
-import * as Units from "utils/units";
-import * as compact from "lodash.compact";
 
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
@@ -305,7 +307,7 @@ describe("Token API (Integration Tests)", () => {
                 test("should throw MISSING_ERC20_METHOD", async () => {
                     await expect(
                         tokenApi.getBalanceAsync(nonERC20.address, SPENDER),
-                    ).rejects.toThrow(TokenAssertionErrors.MISSING_ERC20_METHOD());
+                    ).rejects.toThrow(TokenAssertionErrors.MISSING_ERC20_METHOD(nonERC20.address));
                 });
             });
 

--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -116,7 +116,7 @@ describe("Token API (Integration Tests)", () => {
                             new BigNumber(10),
                             { from: SPENDER },
                         ),
-                    ).rejects.toThrow(TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE());
+                    ).rejects.toThrow(TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE(SPENDER));
                 });
             });
 
@@ -204,11 +204,11 @@ describe("Token API (Integration Tests)", () => {
                             new BigNumber(10),
                             { from: OPERATOR },
                         ),
-                    ).rejects.toThrow(TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE());
+                    ).rejects.toThrow(TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE(SPENDER));
                 });
             });
 
-            describe("sender has insufficient allowance", async () => {
+            describe("spender has given operator insufficient allowance", async () => {
                 test("should throw INSUFFICIENT_SENDER_ALLOWANCE", async () => {
                     await expect(
                         tokenApi.transferFromAsync(

--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -108,10 +108,13 @@ describe("Token API (Integration Tests)", () => {
 
                 test("should throw INSUFFICIENT_SENDER_BALANCE", async () => {
                     await expect(
-                        tokenApi.transferAsync(dummyREPToken.address, RECIPIENT, new BigNumber(10), { from: SPENDER }),
-                    ).rejects.toThrow(
-                        TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE()
-                    );
+                        tokenApi.transferAsync(
+                            dummyREPToken.address,
+                            RECIPIENT,
+                            new BigNumber(10),
+                            { from: SPENDER },
+                        ),
+                    ).rejects.toThrow(TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE());
                 });
             });
 
@@ -191,29 +194,29 @@ describe("Token API (Integration Tests)", () => {
                 });
 
                 test("should throw INSUFFICIENT_SENDER_BALANCE", async () => {
-                    await expect(tokenApi.transferFromAsync(
-                        dummyZRXToken.address,
-                        SPENDER,
-                        RECIPIENT,
-                        new BigNumber(10),
-                        { from: OPERATOR },
-                    )).rejects.toThrow(
-                        TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE()
-                    );
+                    await expect(
+                        tokenApi.transferFromAsync(
+                            dummyZRXToken.address,
+                            SPENDER,
+                            RECIPIENT,
+                            new BigNumber(10),
+                            { from: OPERATOR },
+                        ),
+                    ).rejects.toThrow(TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE());
                 });
             });
 
             describe("sender has insufficient allowance", async () => {
                 test("should throw INSUFFICIENT_SENDER_ALLOWANCE", async () => {
-                    await expect(tokenApi.transferFromAsync(
-                        dummyZRXToken.address,
-                        SPENDER,
-                        RECIPIENT,
-                        new BigNumber(10),
-                        { from: OPERATOR },
-                    )).rejects.toThrow(
-                        TokenAPIErrors.INSUFFICIENT_SENDER_ALLOWANCE()
-                    );
+                    await expect(
+                        tokenApi.transferFromAsync(
+                            dummyZRXToken.address,
+                            SPENDER,
+                            RECIPIENT,
+                            new BigNumber(10),
+                            { from: OPERATOR },
+                        ),
+                    ).rejects.toThrow(TokenAPIErrors.INSUFFICIENT_SENDER_ALLOWANCE());
                 });
             });
 
@@ -299,7 +302,7 @@ describe("Token API (Integration Tests)", () => {
                     nonERC20 = await contractsApi.loadRepaymentRouterAsync();
                 });
 
-                test("should throw CONTRACT_DOES_NOT_IMPLEMENT_ERC20", async () => {
+                test("should throw MISSING_ERC20_METHOD", async () => {
                     await expect(
                         tokenApi.getBalanceAsync(nonERC20.address, SPENDER),
                     ).rejects.toThrow(TokenAssertionErrors.MISSING_ERC20_METHOD());

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -10,8 +10,8 @@ import { TxData } from "../types";
 const TRANSFER_GAS_MAXIMUM = 70000;
 
 export const TokenAPIErrors = {
-    INSUFFICIENT_SENDER_BALANCE: () =>
-        singleLineString`SENDER does not have sufficient balance in the specified token
+    INSUFFICIENT_SENDER_BALANCE: spenderAddress =>
+        singleLineString`Sender with address ${spenderAddress} does not have sufficient balance in the specified token
                          to execute this transfer.`,
     INSUFFICIENT_SENDER_ALLOWANCE: () =>
         singleLineString`SENDER does not have sufficient allowance in the specified token
@@ -55,7 +55,7 @@ export class TokenAPI {
             tokenContract,
             options.from,
             value,
-            TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE(),
+            TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE(options.from),
         );
 
         return tokenContract.transfer.sendTransactionAsync(to, value, transactionOptions);
@@ -90,7 +90,7 @@ export class TokenAPI {
             tokenContract,
             from,
             value,
-            TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE(),
+            TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE(from),
         );
 
         await this.assert.token.hasSufficientAllowance(

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -55,7 +55,7 @@ export class TokenAPI {
             tokenContract,
             options.from,
             value,
-            TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE()
+            TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE(),
         );
 
         return tokenContract.transfer.sendTransactionAsync(to, value, transactionOptions);
@@ -90,7 +90,7 @@ export class TokenAPI {
             tokenContract,
             from,
             value,
-            TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE()
+            TokenAPIErrors.INSUFFICIENT_SENDER_BALANCE(),
         );
 
         await this.assert.token.hasSufficientAllowance(
@@ -98,7 +98,7 @@ export class TokenAPI {
             from,
             options.from,
             value,
-            TokenAPIErrors.INSUFFICIENT_SENDER_ALLOWANCE()
+            TokenAPIErrors.INSUFFICIENT_SENDER_ALLOWANCE(),
         );
 
         return tokenContract.transferFrom.sendTransactionAsync(from, to, value, transactionOptions);
@@ -137,6 +137,9 @@ export class TokenAPI {
         Object.assign(transactionOptions, options);
 
         const tokenContract = await this.contracts.loadERC20TokenAsync(tokenAddress);
+
+        await this.assert.token.implementsERC20(tokenContract);
+
         const tokenTransferProxy = await this.contracts.loadTokenTransferProxyAsync();
 
         return tokenContract.approve.sendTransactionAsync(
@@ -157,6 +160,10 @@ export class TokenAPI {
         tokenAddress: string,
         options?: TxData,
     ): Promise<string> {
+        const tokenContract = await this.contracts.loadERC20TokenAsync(tokenAddress);
+
+        await this.assert.token.implementsERC20(tokenContract);
+
         // We set an allowance to be "unlimited" by setting it to
         // it's maximum possible value -- namely, 2^256 - 1.
         const unlimitedAllowance = new BigNumber(2).pow(256).sub(1);
@@ -177,6 +184,9 @@ export class TokenAPI {
         ownerAddress: string,
     ): Promise<BigNumber> {
         const tokenContract = await this.contracts.loadERC20TokenAsync(tokenAddress);
+
+        await this.assert.token.implementsERC20(tokenContract);
+
         const tokenTransferProxy = await this.contracts.loadTokenTransferProxyAsync();
 
         return tokenContract.allowance.callAsync(ownerAddress, tokenTransferProxy.address);

--- a/src/invariants/token.ts
+++ b/src/invariants/token.ts
@@ -4,42 +4,22 @@ import { ERC20Contract } from "../wrappers";
 import * as singleLineString from "single-line-string";
 
 export const TokenAssertionErrors = {
-    MISSING_ERC20_METHOD: () =>
-        singleLineString`Contract does not implement ERC20 interface.`,
+    MISSING_ERC20_METHOD: (contractAddress: string) =>
+        singleLineString`Contract at ${contractAddress} does not implement ERC20 interface.`,
 };
 
 export class TokenAssertions {
     // Throws an error if the given candidateContract does not implement the ERC20 interface.
-    public async implementsERC20(candidate: any): Promise<void> {
+    public async implementsERC20(candidate: ERC20Contract): Promise<void> {
+        const address = candidate.address;
+
         try {
-            await candidate.balanceOf.callAsync(candidate.address);
+            // NOTE: Needs to check more methods to validate complete ERC20 interface.
+            await candidate.balanceOf.callAsync(address);
             await candidate.totalSupply.callAsync();
         } catch (error) {
-            throw new Error(TokenAssertionErrors.MISSING_ERC20_METHOD());
+            throw new Error(TokenAssertionErrors.MISSING_ERC20_METHOD(address));
         }
-
-        /*
-            Alternative, something like this could work"
-
-            // An ERC20 contract must at least implement the following methods:
-            const specMethods = [
-                'name',
-                'symbol',
-                'decimals',
-                'totalSupply',
-                'balanceOf',
-                'transfer',
-                'transferFrom',
-                'approve',
-                'allowance'
-            ];
-
-            specMethods.map((method: string) => {
-                if (!candidate.hasOwnProperty(method)) {
-                    throw new Error(TokenAssertionErrors.MISSING_ERC20_METHOD(method));
-                }
-            });
-        */
     }
 
     public async hasSufficientBalance(

--- a/src/invariants/token.ts
+++ b/src/invariants/token.ts
@@ -1,7 +1,47 @@
 import { BigNumber } from "bignumber.js";
 import { ERC20Contract } from "../wrappers";
 
+import * as singleLineString from "single-line-string";
+
+export const TokenAssertionErrors = {
+    MISSING_ERC20_METHOD: () =>
+        singleLineString`Contract does not implement ERC20 interface.`,
+};
+
 export class TokenAssertions {
+    // Throws an error if the given candidateContract does not implement the ERC20 interface.
+    public async implementsERC20(candidate: any): Promise<void> {
+        try {
+            await candidate.balanceOf.callAsync(candidate.address);
+            await candidate.totalSupply.callAsync();
+        } catch (error) {
+            throw new Error(TokenAssertionErrors.MISSING_ERC20_METHOD());
+        }
+
+        /*
+            Alternative, something like this could work"
+
+            // An ERC20 contract must at least implement the following methods:
+            const specMethods = [
+                'name',
+                'symbol',
+                'decimals',
+                'totalSupply',
+                'balanceOf',
+                'transfer',
+                'transferFrom',
+                'approve',
+                'allowance'
+            ];
+
+            specMethods.map((method: string) => {
+                if (!candidate.hasOwnProperty(method)) {
+                    throw new Error(TokenAssertionErrors.MISSING_ERC20_METHOD(method));
+                }
+            });
+        */
+    }
+
     public async hasSufficientBalance(
         principalToken: ERC20Contract,
         payer: string,

--- a/src/schemas/basic_type_schemas.ts
+++ b/src/schemas/basic_type_schemas.ts
@@ -12,12 +12,17 @@ export const bytes32Schema = {
 
 export const numberSchema = {
     id: "/Number",
-    type: "string",
-    pattern: "^\\d+(\\.\\d+)?$",
+    type: "object",
+    properties: {
+        // BigNumber.js objects have a boolean method isBigNumber.
+        isBigNumber: { type: "boolean" },
+    },
+    required: ["isBigNumber"],
+    format: "BigNumber",
 };
 
 export const wholeNumberSchema = {
     id: "/WholeNumber",
-    type: "string",
-    pattern: "^\\d+$",
+    type: "object",
+    format: "wholeBigNumber",
 };

--- a/src/schemas/basic_type_schemas.ts
+++ b/src/schemas/basic_type_schemas.ts
@@ -14,7 +14,6 @@ export const numberSchema = {
     id: "/Number",
     type: "object",
     properties: {
-        // BigNumber.js objects have a boolean method isBigNumber.
         isBigNumber: { type: "boolean" },
     },
     required: ["isBigNumber"],

--- a/src/schemas/custom_formats.ts
+++ b/src/schemas/custom_formats.ts
@@ -1,8 +1,8 @@
 export const bigNumberFormat = function(input) {
     const regex = RegExp("^\\d+(\\.\\d+)?$");
-    // The input's format only matters if the input is required, in which case
-    // the validator will throw an error for an undefined input at another point. Hence, we do not
-    // need to validate presence here.
+    // The input's format only matters if the input is required (in which case
+    // an undefined value will cause the validator to throw an error at another point.)
+    // Hence, we do not need to validate presence here.
     return input === undefined || (input.isBigNumber && regex.test(input.toString()));
 };
 

--- a/src/schemas/custom_formats.ts
+++ b/src/schemas/custom_formats.ts
@@ -1,0 +1,12 @@
+export const bigNumberFormat = function(input) {
+    const regex = RegExp("^\\d+(\\.\\d+)?$");
+    // The input's format only matters if the input is required, in which case
+    // the validator will throw an error for an undefined input at another point. Hence, we do not
+    // need to validate presence here.
+    return input === undefined || (input.isBigNumber && regex.test(input.toString()));
+};
+
+export const wholeBigNumberFormat = function(input) {
+    const regex = RegExp("^\\d+$");
+    return input === undefined || (input.isBigNumber && regex.test(input.toString()));
+};

--- a/src/schemas/custom_formats.ts
+++ b/src/schemas/custom_formats.ts
@@ -1,8 +1,9 @@
+// NOTE: The input's format only matters if the input is required (since, if an input
+// is required by the schema but undefined, the validator will throw an error at another point.)
+// Hence, we can skip validating format if the input is undefined.
+
 export const bigNumberFormat = function(input) {
     const regex = RegExp("^\\d+(\\.\\d+)?$");
-    // The input's format only matters if the input is required (in which case
-    // an undefined value will cause the validator to throw an error at another point.)
-    // Hence, we do not need to validate presence here.
     return input === undefined || (input.isBigNumber && regex.test(input.toString()));
 };
 

--- a/src/schemas/schema_validator.ts
+++ b/src/schemas/schema_validator.ts
@@ -26,7 +26,7 @@ export class SchemaValidator {
         Validator.prototype.customFormats.BigNumber = function(input) {
             const regex = RegExp("^\\d+(\\.\\d+)?$");
             // This allows undefined inputs, e.g. salt is not present sometimes.
-            return !input || (input.isBigNumber && regex.test(input.toString()));
+            return input === undefined || (input.isBigNumber && regex.test(input.toString()));
         };
 
         Validator.prototype.customFormats.wholeBigNumber = function(input) {

--- a/src/schemas/schema_validator.ts
+++ b/src/schemas/schema_validator.ts
@@ -3,6 +3,8 @@ import * as values from "lodash.values";
 
 import { Schemas } from "./schemas";
 
+import * as customFormats from "./custom_formats";
+
 /**
  * Borrowed, with slight modification, from the wonderful 0x.js project codebase:
  * https://github.com/0xProject/0x.js/tree/development/packages/json-schemas
@@ -12,6 +14,8 @@ export class SchemaValidator {
 
     constructor() {
         this._validator = new Validator();
+
+        this.addCustomValidators();
 
         for (const schema of values(Schemas)) {
             this._validator.addSchema(schema, schema.id);
@@ -23,22 +27,16 @@ export class SchemaValidator {
     }
 
     public validate(instance: any, schema: Schema): ValidatorResult {
-        Validator.prototype.customFormats.BigNumber = function(input) {
-            const regex = RegExp("^\\d+(\\.\\d+)?$");
-            // This allows undefined inputs, e.g. salt is not present sometimes.
-            return input === undefined || (input.isBigNumber && regex.test(input.toString()));
-        };
-
-        Validator.prototype.customFormats.wholeBigNumber = function(input) {
-            const regex = RegExp("^\\d+$");
-            return input && input.isBigNumber && regex.test(input.toString());
-        };
-
         return this._validator.validate(instance, schema);
     }
 
     public isValid(instance: any, schema: Schema): boolean {
         const isValid = this.validate(instance, schema).errors.length === 0;
         return isValid;
+    }
+
+    public addCustomValidators() {
+        this._validator.customFormats.BigNumber = customFormats.bigNumberFormat;
+        this._validator.customFormats.wholeBigNumber = customFormats.wholeBigNumberFormat;
     }
 }


### PR DESCRIPTION
* Adds some tests for Token API, including:
  * transferAsync checks that sender has sufficient balance, throw if not the case
  * transferFromAsync checks that sender has sufficient balance and allowance
  * getBalanceAsync throws if contract does not implement ERC20 interface
  * setProxyAllowance throws if contract does not implement the ERC20 interface
  * setUnlimitedProxyAllowance throws if contract does not implement the ERC20 interface
  * getProxyAllowanceAsync throws if contract does not implement the ERC20 interface
* Removes hack to validate JSONSchema of BigNumbers, by adding custom format validator