### PR TITLE
Patch dharma.js tests that mock pulling contract artifacts

### DIFF
--- a/__mocks__/@dharmaprotocol/MockContract.ts
+++ b/__mocks__/@dharmaprotocol/MockContract.ts
@@ -1,0 +1,11 @@
+import * as Web3 from "web3";
+
+export class MockContract {
+    public static abi: Web3.AbiDefinition[];
+    public static networks: object;
+
+    public static mock(abi: Web3.AbiDefinition[], networks: object) {
+        MockContract.abi = abi;
+        MockContract.networks = networks;
+    }
+}

--- a/__mocks__/@dharmaprotocol/contracts.ts
+++ b/__mocks__/@dharmaprotocol/contracts.ts
@@ -1,0 +1,11 @@
+import { MockContract } from "./MockContract";
+
+export class DebtKernel extends MockContract {}
+export class DebtToken extends MockContract {}
+export class DummyToken extends MockContract {}
+export class ERC20 extends MockContract {}
+export class RepaymentRouter extends MockContract {}
+export class SimpleInterestTermsContract extends MockContract {}
+export class TermsContractRegistry extends MockContract {}
+export class TokenRegistry extends MockContract {}
+export class TokenTransferProxy extends MockContract {}

--- a/__test__/integration/order_api/order_scenario_runner.ts
+++ b/__test__/integration/order_api/order_scenario_runner.ts
@@ -4,6 +4,7 @@ import {
     RepaymentRouterContract,
     TokenTransferProxyContract,
     DummyTokenContract,
+    SimpleInterestTermsContractContract,
 } from "src/wrappers";
 import { OrderAPI, SignerAPI } from "src/apis";
 import {
@@ -23,6 +24,7 @@ export class OrderScenarioRunner {
     public repaymentRouter: RepaymentRouterContract;
     public tokenTransferProxy: TokenTransferProxyContract;
     public principalToken: DummyTokenContract;
+    public termsContract: SimpleInterestTermsContractContract;
     public orderApi: OrderAPI;
     public orderSigner: SignerAPI;
     public abiDecoder: any;
@@ -56,6 +58,7 @@ export class OrderScenarioRunner {
                     this.debtKernel,
                     this.repaymentRouter,
                     this.principalToken,
+                    this.termsContract,
                 );
 
                 // We dynamically set the creditor's balance and
@@ -101,6 +104,7 @@ export class OrderScenarioRunner {
                     const txHash = await this.orderApi.fillAsync(debtOrder, {
                         from: scenario.filler,
                     });
+
                     const receipt = await this.web3Utils.getTransactionReceiptAsync(txHash);
 
                     const [debtOrderFilledLog] = compact(ABIDecoder.decodeLogs(receipt.logs));

--- a/__test__/integration/order_api/scenarios/index.ts
+++ b/__test__/integration/order_api/scenarios/index.ts
@@ -1,4 +1,9 @@
-import { DebtKernelContract, RepaymentRouterContract, DummyTokenContract } from "src/wrappers";
+import {
+    DebtKernelContract,
+    RepaymentRouterContract,
+    DummyTokenContract,
+    SimpleInterestTermsContractContract,
+} from "src/wrappers";
 import { VALID_ORDERS } from "./valid_orders";
 import { INVALID_ORDERS } from "./invalid_orders";
 import { NONCONSENUAL_ORDERS } from "./nonconsensual_orders";
@@ -19,6 +24,7 @@ export interface FillScenario {
         debtKernel: DebtKernelContract,
         repaymentRouter: RepaymentRouterContract,
         principalToken: DummyTokenContract,
+        termsContract: SimpleInterestTermsContractContract,
     ) => DebtOrder;
     filler: string;
     signatories: {

--- a/__test__/integration/order_api/scenarios/invalid_orders.ts
+++ b/__test__/integration/order_api/scenarios/invalid_orders.ts
@@ -1,4 +1,9 @@
-import { DebtKernelContract, RepaymentRouterContract, DummyTokenContract } from "src/wrappers";
+import {
+    DebtKernelContract,
+    RepaymentRouterContract,
+    DummyTokenContract,
+    SimpleInterestTermsContractContract,
+} from "src/wrappers";
 import * as Units from "utils/units";
 import * as moment from "moment";
 import { DebtOrder } from "types";
@@ -17,6 +22,7 @@ export const INVALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -32,7 +38,7 @@ export const INVALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.511),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -58,6 +64,7 @@ export const INVALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -73,7 +80,7 @@ export const INVALID_ORDERS: FillScenario[] = [
                 underwriter: NULL_ADDRESS,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -99,6 +106,7 @@ export const INVALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -114,7 +122,7 @@ export const INVALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -140,6 +148,7 @@ export const INVALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -155,7 +164,7 @@ export const INVALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -181,6 +190,7 @@ export const INVALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -196,7 +206,7 @@ export const INVALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -222,6 +232,7 @@ export const INVALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -237,7 +248,7 @@ export const INVALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -273,6 +284,7 @@ export const INVALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -288,7 +300,7 @@ export const INVALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()

--- a/__test__/integration/order_api/scenarios/nonconsensual_orders.ts
+++ b/__test__/integration/order_api/scenarios/nonconsensual_orders.ts
@@ -1,4 +1,9 @@
-import { DebtKernelContract, RepaymentRouterContract, DummyTokenContract } from "src/wrappers";
+import {
+    DebtKernelContract,
+    RepaymentRouterContract,
+    DummyTokenContract,
+    SimpleInterestTermsContractContract,
+} from "src/wrappers";
 import * as Units from "utils/units";
 import * as moment from "moment";
 import { BigNumber } from "bignumber.js";
@@ -15,6 +20,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -30,7 +36,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -56,6 +62,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -71,7 +78,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -97,6 +104,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -112,7 +120,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -142,6 +150,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -157,7 +166,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -184,6 +193,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -199,7 +209,7 @@ export const NONCONSENUAL_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()

--- a/__test__/integration/order_api/scenarios/valid_orders.ts
+++ b/__test__/integration/order_api/scenarios/valid_orders.ts
@@ -1,4 +1,9 @@
-import { DebtKernelContract, RepaymentRouterContract, DummyTokenContract } from "src/wrappers";
+import {
+    DebtKernelContract,
+    RepaymentRouterContract,
+    DummyTokenContract,
+    SimpleInterestTermsContractContract,
+} from "src/wrappers";
 import * as Units from "utils/units";
 import { NULL_ADDRESS, NULL_BYTES32 } from "utils/constants";
 import * as moment from "moment";
@@ -14,6 +19,7 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -26,7 +32,7 @@ export const VALID_ORDERS: FillScenario[] = [
                 creditorFee: Units.ether(0.001),
                 relayer: ACCOUNTS[3].address,
                 relayerFee: Units.ether(0.002),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -50,6 +56,7 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -63,7 +70,7 @@ export const VALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.002),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -87,6 +94,7 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -95,7 +103,7 @@ export const VALID_ORDERS: FillScenario[] = [
                 principalToken: principalToken.address,
                 debtor: ACCOUNTS[1].address,
                 creditor: ACCOUNTS[2].address,
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -119,13 +127,14 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 principalAmount: Units.ether(1),
                 principalToken: principalToken.address,
                 debtor: ACCOUNTS[1].address,
                 creditor: ACCOUNTS[2].address,
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -149,13 +158,14 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 principalAmount: Units.ether(1),
                 principalToken: principalToken.address,
                 debtor: ACCOUNTS[1].address,
                 creditor: ACCOUNTS[2].address,
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 salt: new BigNumber(0),
             };
@@ -174,13 +184,14 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 principalAmount: Units.ether(1),
                 principalToken: principalToken.address,
                 debtor: ACCOUNTS[1].address,
                 creditor: ACCOUNTS[2].address,
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
             };
         },
@@ -198,6 +209,7 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -213,7 +225,7 @@ export const VALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -237,6 +249,7 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -252,7 +265,7 @@ export const VALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -276,6 +289,7 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -291,7 +305,7 @@ export const VALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()
@@ -316,6 +330,7 @@ export const VALID_ORDERS: FillScenario[] = [
             debtKernel: DebtKernelContract,
             repaymentRouter: RepaymentRouterContract,
             principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
         ) => {
             return {
                 kernelVersion: debtKernel.address,
@@ -331,7 +346,7 @@ export const VALID_ORDERS: FillScenario[] = [
                 underwriter: ACCOUNTS[4].address,
                 underwriterFee: Units.ether(0.001),
                 underwriterRiskRating: Units.percent(0.001),
-                termsContract: ACCOUNTS[5].address,
+                termsContract: termsContract.address,
                 termsContractParameters: NULL_BYTES32,
                 expirationTimestampInSec: new BigNumber(
                     moment()

--- a/__test__/integration/servicing_api.spec.ts
+++ b/__test__/integration/servicing_api.spec.ts
@@ -17,6 +17,11 @@ import { NULL_BYTES32 } from "../../utils/constants";
 import * as ABIDecoder from "abi-decoder";
 import * as moment from "moment";
 
+// Given that this is an integration test, we unmock the Dharma
+// smart contracts artifacts package to pull the most recently
+// deployed contracts on the current network.
+jest.unmock("@dharmaprotocol/contracts");
+
 const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
 const web3Utils = new Web3Utils(web3);
 

--- a/__test__/integration/signer_api.spec.ts
+++ b/__test__/integration/signer_api.spec.ts
@@ -10,6 +10,11 @@ import { Web3Utils } from "utils/web3_utils";
 
 import { ACCOUNTS, NULL_ADDRESS } from "../accounts";
 
+// Given that this is an integration test, we unmock the Dharma
+// smart contracts artifacts package to pull the most recently
+// deployed contracts on the current network.
+jest.unmock("@dharmaprotocol/contracts");
+
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const contractsApi = new ContractsAPI(web3);

--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -14,6 +14,11 @@ import { DummyTokenContract, TokenTransferProxyContract } from "src/wrappers";
 
 import { ACCOUNTS } from "../accounts";
 
+// Given that this is an integration test, we unmock the Dharma
+// smart contracts artifacts package to pull the most recently
+// deployed contracts on the current network.
+jest.unmock("@dharmaprotocol/contracts");
+
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const web3Utils = new Web3Utils(web3);

--- a/__test__/unit/adapters/simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/simple_interest_loan_adapter.spec.ts
@@ -19,6 +19,11 @@ const simpleInterestLoanTerms = new SimpleInterestLoanTerms(web3);
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 
+// Given that we rely on having access to the deployed Dharma smart contracts,
+// we unmock the Dharma smart contracts artifacts package to pull the most recently
+// deployed contracts on the current network.
+jest.unmock("@dharmaprotocol/contracts");
+
 // Unmock the "fs-extra" package in order to give us
 // access to the deployed TokenRegistry on the
 // test chain.

--- a/__test__/unit/debt_kernel_wrapper.spec.ts
+++ b/__test__/unit/debt_kernel_wrapper.spec.ts
@@ -1,4 +1,4 @@
-jest.mock("src/artifacts/ts/DebtKernel");
+jest.mock("@dharmaprotocol/contracts");
 
 import * as promisify from "tiny-promisify";
 import { Web3Utils } from "utils/web3_utils";
@@ -7,7 +7,7 @@ import { CONTRACT_WRAPPER_ERRORS } from "src/wrappers/contract_wrappers/base_con
 import { ACCOUNTS } from "../accounts";
 import * as Web3 from "web3";
 
-import { DebtKernel as ContractArtifactsMock } from "src/artifacts/ts/DebtKernel";
+import { DebtKernel as ContractArtifactsMock } from "@dharmaprotocol/contracts";
 
 // We use an unmocked version of "fs" in order to pull the correct
 // contract address from our artifacts for testing purposes
@@ -17,7 +17,8 @@ const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const web3Utils = new Web3Utils(web3);
 
-const DEBT_KERNEL_RAW_ARTIFACTS_PATH = "src/artifacts/json/DebtKernel.json";
+const DEBT_KERNEL_RAW_ARTIFACTS_PATH =
+    "node_modules/@dharmaprotocol/contracts/artifacts/json/DebtKernel.json";
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 

--- a/__test__/unit/debt_token_wrapper.spec.ts
+++ b/__test__/unit/debt_token_wrapper.spec.ts
@@ -1,4 +1,4 @@
-jest.mock("src/artifacts/ts/DebtToken");
+jest.mock("@dharmaprotocol/contracts");
 
 import * as promisify from "tiny-promisify";
 import * as Web3 from "web3";
@@ -11,7 +11,7 @@ import { NULL_ADDRESS } from "utils/constants";
 import { Web3Utils } from "utils/web3_utils";
 
 import { DebtTokenContract } from "src/wrappers";
-import { DebtToken as MockContractArtifacts } from "src/artifacts/ts/DebtToken";
+import { DebtToken as MockContractArtifacts } from "@dharmaprotocol/contracts";
 import { CONTRACT_WRAPPER_ERRORS } from "src/wrappers/contract_wrappers/base_contract_wrapper";
 import { ACCOUNTS } from "../accounts";
 
@@ -19,7 +19,8 @@ const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const web3Utils = new Web3Utils(web3);
 
-const DEBT_TOKEN_ARTIFACTS_PATH = "src/artifacts/json/DebtToken.json";
+const DEBT_TOKEN_ARTIFACTS_PATH =
+    "node_modules/@dharmaprotocol/contracts/artifacts/json/DebtToken.json";
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 

--- a/__test__/unit/dummy_token_wrapper.spec.ts
+++ b/__test__/unit/dummy_token_wrapper.spec.ts
@@ -1,9 +1,12 @@
-jest.mock("src/artifacts/ts/DummyToken");
+jest.mock("@dharmaprotocol/contracts");
 
 import * as promisify from "tiny-promisify";
 import { Web3Utils } from "utils/web3_utils";
 import { DummyTokenContract, TokenRegistryContract } from "src/wrappers";
-import { DummyToken as MockContractArtifacts } from "src/artifacts/ts/DummyToken";
+import {
+    DummyToken as DummyTokenMockArtifacts,
+    TokenRegistry as TokenRegistryMockArtifacts,
+} from "@dharmaprotocol/contracts";
 import { CONTRACT_WRAPPER_ERRORS } from "src/wrappers/contract_wrappers/base_contract_wrapper";
 import { ACCOUNTS } from "../accounts";
 import * as Web3 from "web3";
@@ -16,26 +19,53 @@ const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const web3Utils = new Web3Utils(web3);
 
-const DUMMY_TOKEN_ARTIFACTS_PATH = "src/artifacts/json/DummyToken.json";
+const DUMMY_TOKEN_ARTIFACTS_PATH =
+    "node_modules/@dharmaprotocol/contracts/artifacts/json/DummyToken.json";
+const TOKEN_REGISTRY_ARTIFACTS_PATH =
+    "node_modules/@dharmaprotocol/contracts/artifacts/json/TokenRegistry.json";
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 
 describe("Dummy Token Contract Wrapper (Unit)", () => {
     let networkId: number;
     let dummyTokenContractAbi: Web3.ContractAbi;
-    let dummyREPTokenAddress: string;
+    let tokenRegistryContractAbi: Web3.ContractAbi;
+
+    let REPTokenAddress: string;
 
     beforeAll(async () => {
         networkId = await web3Utils.getNetworkIdAsync();
 
         const readFilePromise = promisify(fs.readFile);
-        const dummyTokenArtifacts = await readFilePromise(DUMMY_TOKEN_ARTIFACTS_PATH);
-        const { abi } = JSON.parse(dummyTokenArtifacts);
 
+        // When we mock @dharmaprotocol/contracts, *all* contracts become by
+        // default mocked.  Thus, if we depend on accessing any contract at
+        // any point in time during this test, it needs to be mocked in some capacity.
+        //
+        // Given that we depend on the token registry to pull the addresses of
+        // dummy token contracts deployed on the current network, we have to manually
+        // retrieve and mock its artifacts alongside the dummy token artifacts.
+        const dummyTokenArtifacts = await readFilePromise(DUMMY_TOKEN_ARTIFACTS_PATH);
+        const tokenRegistryArtifacts = await readFilePromise(TOKEN_REGISTRY_ARTIFACTS_PATH);
+
+        // Pull, parse, and store for later use dummy token's ABI from JSON artifacts
+        const { abi } = JSON.parse(dummyTokenArtifacts);
         dummyTokenContractAbi = abi;
 
-        const dummyTokenRegistry = await TokenRegistryContract.deployed(web3, TX_DEFAULTS);
-        dummyREPTokenAddress = await dummyTokenRegistry.getTokenAddress.callAsync("REP");
+        // Pull, parse, and store token registry's abi / network metadata
+        // contract.
+        const {
+            abi: tokenRegistryContractAbi,
+            networks: tokenRegistryContractNetworks,
+        } = JSON.parse(tokenRegistryArtifacts);
+
+        // Mock the returned token registry artifacts using the stored abi / network metadata
+        TokenRegistryMockArtifacts.mock(tokenRegistryContractAbi, tokenRegistryContractNetworks);
+
+        // Now that our contract artifacts are mocked, the TokenRegistryContract wrapper should
+        // work as intended, and allow us to pull the address of a deployed ERC20 token.
+        const tokenRegistry = await TokenRegistryContract.deployed(web3, TX_DEFAULTS);
+        REPTokenAddress = await tokenRegistry.getTokenAddress.callAsync("REP");
     });
 
     // TODO: Create tests for general solidity method calls on the Debt Token contract
@@ -48,7 +78,7 @@ describe("Dummy Token Contract Wrapper (Unit)", () => {
                     address: ACCOUNTS[0].address,
                 };
 
-                MockContractArtifacts.mock(dummyTokenContractAbi, mockNetworks);
+                DummyTokenMockArtifacts.mock(dummyTokenContractAbi, mockNetworks);
             });
 
             test("throws CONTRACT_NOT_FOUND_ON_NETWORK error", async () => {
@@ -68,17 +98,17 @@ describe("Dummy Token Contract Wrapper (Unit)", () => {
                     address: ACCOUNTS[0].address,
                 };
 
-                MockContractArtifacts.mock(dummyTokenContractAbi, mockNetworks);
+                DummyTokenMockArtifacts.mock(dummyTokenContractAbi, mockNetworks);
             });
 
             test("returns new DebtKernelWrapper w/ current address correctly set", async () => {
                 const contractWrapper = await DummyTokenContract.at(
-                    dummyREPTokenAddress,
+                    REPTokenAddress,
                     web3,
                     TX_DEFAULTS,
                 );
 
-                expect(contractWrapper.address).toBe(dummyREPTokenAddress);
+                expect(contractWrapper.address).toBe(REPTokenAddress);
                 expect(contractWrapper.abi).toEqual(dummyTokenContractAbi);
             });
         });

--- a/__test__/unit/erc20_wrapper.spec.ts
+++ b/__test__/unit/erc20_wrapper.spec.ts
@@ -1,9 +1,12 @@
-jest.mock("src/artifacts/ts/ERC20");
+jest.mock("@dharmaprotocol/contracts");
 
 import * as promisify from "tiny-promisify";
 import { Web3Utils } from "utils/web3_utils";
 import { ERC20Contract, TokenRegistryContract } from "src/wrappers";
-import { ERC20 as MockContractArtifacts } from "src/artifacts/ts/ERC20";
+import {
+    ERC20 as ERC20TokenMockArtifacts,
+    TokenRegistry as TokenRegistryMockArtifacts,
+} from "@dharmaprotocol/contracts";
 import { CONTRACT_WRAPPER_ERRORS } from "src/wrappers/contract_wrappers/base_contract_wrapper";
 import { ACCOUNTS } from "../accounts";
 import * as Web3 from "web3";
@@ -16,26 +19,50 @@ const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const web3Utils = new Web3Utils(web3);
 
-const ERC20_ARTIFACTS_PATH = "src/artifacts/json/ERC20.json";
+const TOKEN_REGISTRY_ARTIFACTS_PATH =
+    "node_modules/@dharmaprotocol/contracts/artifacts/json/TokenRegistry.json";
+const ERC20_ARTIFACTS_PATH = "node_modules/@dharmaprotocol/contracts/artifacts/json/ERC20.json";
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 
 describe("ERC20 Token Contract Wrapper (Unit)", () => {
     let networkId: number;
     let erc20TokenContractAbi: Web3.ContractAbi;
-    let dummyREPTokenAddress: string;
+    let REPTokenAddress: string;
 
     beforeAll(async () => {
         networkId = await web3Utils.getNetworkIdAsync();
 
         const readFilePromise = promisify(fs.readFile);
-        const dummyTokenArtifacts = await readFilePromise(ERC20_ARTIFACTS_PATH);
-        const { abi } = JSON.parse(dummyTokenArtifacts);
 
+        // When we mock @dharmaprotocol/contracts, *all* contracts become by
+        // default mocked.  Thus, if we depend on accessing any contract at
+        // any point in time during this test, it needs to be mocked in some capacity.
+        //
+        // Given that we depend on the token registry to pull the addresses of
+        // ERC20 contracts deployed on the current network, we have to manually
+        // retrieve and mock its artifacts alongside the ERC20 artifacts.
+        const erc20TokenArtifacts = await readFilePromise(ERC20_ARTIFACTS_PATH);
+        const tokenRegistryArtifacts = await readFilePromise(TOKEN_REGISTRY_ARTIFACTS_PATH);
+
+        // Pull, parse, and store for later use erc20 token's ABI from JSON artifacts
+        const { abi } = JSON.parse(erc20TokenArtifacts);
         erc20TokenContractAbi = abi;
 
-        const dummyTokenRegistry = await TokenRegistryContract.deployed(web3, TX_DEFAULTS);
-        dummyREPTokenAddress = await dummyTokenRegistry.getTokenAddress.callAsync("REP");
+        // Pull, parse, and store token registry's abi / network metadata
+        // contract.
+        const {
+            abi: tokenRegistryContractAbi,
+            networks: tokenRegistryContractNetworks,
+        } = JSON.parse(tokenRegistryArtifacts);
+
+        // Mock the returned token registry artifacts using the stored abi / network metadata
+        TokenRegistryMockArtifacts.mock(tokenRegistryContractAbi, tokenRegistryContractNetworks);
+
+        // Now that our contract artifacts are mocked, the TokenRegistryContract wrapper should
+        // work as intended, and allow us to pull the address of a deployed ERC20 token.
+        const tokenRegistry = await TokenRegistryContract.deployed(web3, TX_DEFAULTS);
+        REPTokenAddress = await tokenRegistry.getTokenAddress.callAsync("REP");
     });
 
     // TODO: Create tests for general solidity method calls on the Debt Token contract
@@ -48,7 +75,7 @@ describe("ERC20 Token Contract Wrapper (Unit)", () => {
                     address: ACCOUNTS[0].address,
                 };
 
-                MockContractArtifacts.mock(erc20TokenContractAbi, mockNetworks);
+                ERC20TokenMockArtifacts.mock(erc20TokenContractAbi, mockNetworks);
             });
 
             test("throws CONTRACT_NOT_FOUND_ON_NETWORK error", async () => {
@@ -68,17 +95,13 @@ describe("ERC20 Token Contract Wrapper (Unit)", () => {
                     address: ACCOUNTS[0].address,
                 };
 
-                MockContractArtifacts.mock(erc20TokenContractAbi, mockNetworks);
+                ERC20TokenMockArtifacts.mock(erc20TokenContractAbi, mockNetworks);
             });
 
             test("returns new DebtKernelWrapper w/ current address correctly set", async () => {
-                const contractWrapper = await ERC20Contract.at(
-                    dummyREPTokenAddress,
-                    web3,
-                    TX_DEFAULTS,
-                );
+                const contractWrapper = await ERC20Contract.at(REPTokenAddress, web3, TX_DEFAULTS);
 
-                expect(contractWrapper.address).toBe(dummyREPTokenAddress);
+                expect(contractWrapper.address).toBe(REPTokenAddress);
                 expect(contractWrapper.abi).toEqual(erc20TokenContractAbi);
             });
         });

--- a/__test__/unit/token_registry_wrapper.spec.ts
+++ b/__test__/unit/token_registry_wrapper.spec.ts
@@ -1,9 +1,9 @@
-jest.mock("src/artifacts/ts/TokenRegistry");
+jest.mock("@dharmaprotocol/contracts");
 
 import * as promisify from "tiny-promisify";
 import { Web3Utils } from "utils/web3_utils";
 import { TokenRegistryContract } from "src/wrappers";
-import { TokenRegistry as MockContractArtifacts } from "src/artifacts/ts/TokenRegistry";
+import { TokenRegistry as MockContractArtifacts } from "@dharmaprotocol/contracts";
 import { CONTRACT_WRAPPER_ERRORS } from "src/wrappers/contract_wrappers/base_contract_wrapper";
 import { ACCOUNTS } from "../accounts";
 import * as Web3 from "web3";
@@ -16,7 +16,8 @@ const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const web3Utils = new Web3Utils(web3);
 
-const TOKEN_REGISTRY_ARTIFACTS_PATH = "src/artifacts/json/TokenRegistry.json";
+const TOKEN_REGISTRY_ARTIFACTS_PATH =
+    "node_modules/@dharmaprotocol/contracts/artifacts/json/TokenRegistry.json";
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 

--- a/__test__/unit/token_transfer_proxy_wrapper.spec.ts
+++ b/__test__/unit/token_transfer_proxy_wrapper.spec.ts
@@ -1,9 +1,9 @@
-jest.mock("src/artifacts/ts/TokenTransferProxy");
+jest.mock("@dharmaprotocol/contracts");
 
 import * as promisify from "tiny-promisify";
 import { Web3Utils } from "utils/web3_utils";
 import { TokenTransferProxyContract } from "src/wrappers";
-import { TokenTransferProxy as MockContractArtifacts } from "src/artifacts/ts/TokenTransferProxy";
+import { TokenTransferProxy as MockContractArtifacts } from "@dharmaprotocol/contracts";
 import { CONTRACT_WRAPPER_ERRORS } from "src/wrappers/contract_wrappers/base_contract_wrapper";
 import { ACCOUNTS } from "../accounts";
 import * as Web3 from "web3";
@@ -16,7 +16,8 @@ const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const web3Utils = new Web3Utils(web3);
 
-const TOKEN_TRANSFER_PROXY_ARTIFACTS_PATH = "src/artifacts/json/TokenTransferProxy.json";
+const TOKEN_TRANSFER_PROXY_ARTIFACTS_PATH =
+    "node_modules/@dharmaprotocol/contracts/artifacts/json/TokenTransferProxy.json";
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 


### PR DESCRIPTION
This PR introduces the following changes to  [PR#13](https://github.com/dharmaprotocol/dharma.js/pull/13):

- Fixes unit tests that fail in PR13 due to outdated mocking procedures
- Fixes unit tests that fail in PR13 due to the newly introduced order fill hook introduced by [charta/PR32](https://github.com/dharmaprotocol/charta/pull/32)  (which requires that a terms contract specified in a debt order return `true` to `registerTermStart`)