### PR TITLE
Fix for error logs

### DIFF
--- a/__test__/unit/blockchain_api/blockchain_api.spec.ts
+++ b/__test__/unit/blockchain_api/blockchain_api.spec.ts
@@ -16,7 +16,7 @@ import { BlockchainAPI, ContractsAPI, TokenAPI } from "src/apis/";
 import { Logging, DebtKernelError, DebtOrder } from "src/types";
 import { ACCOUNTS } from "../../accounts";
 import { ErrorScenarioRunner } from "./error_scenario_runner";
-import { INVALID_ORDERS } from "./scenarios";
+import { INVALID_ORDERS, VALID_ORDERS } from "./scenarios";
 import { DebtOrderWrapper } from "src/wrappers";
 
 const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
@@ -38,6 +38,9 @@ describe("Blockchain API (Unit Tests)", () => {
         });
         describe("invalid orders should result in retrievable error logs", () => {
             INVALID_ORDERS.forEach(scenarioRunner.testDebtKernelErrorScenario);
+        });
+        describe("valid orders should result in no error logs", () => {
+            VALID_ORDERS.forEach(scenarioRunner.testDebtKernelErrorScenario);
         });
     });
 

--- a/__test__/unit/blockchain_api/error_scenario_runner.ts
+++ b/__test__/unit/blockchain_api/error_scenario_runner.ts
@@ -149,11 +149,18 @@ export class ErrorScenarioRunner {
                 );
             });
 
-            test("it returns the correct human-readable error message", async () => {
-                const errors = await this.blockchainAPI.getErrorLogs(txHash);
-                expect(errors.length).toEqual(1);
-                expect(errors[0]).toEqual(DebtKernelError.messageForError(scenario.error));
-            });
+            if (scenario.error != null) {
+                test("it returns the correct human-readable error message", async () => {
+                    const errors = await this.blockchainAPI.getErrorLogs(txHash);
+                    expect(errors.length).toEqual(1);
+                    expect(errors[0]).toEqual(DebtKernelError.messageForError(scenario.error));
+                });
+            } else {
+                test("it returns no error messages", async () => {
+                    const errors = await this.blockchainAPI.getErrorLogs(txHash);
+                    expect(errors.length).toEqual(0);
+                });
+            }
         });
     }
 

--- a/__test__/unit/blockchain_api/scenarios/error_scenarios.ts
+++ b/__test__/unit/blockchain_api/scenarios/error_scenarios.ts
@@ -16,7 +16,7 @@ export interface DebtKernelErrorScenario {
         principalToken: DummyTokenContract,
         termsContract: SimpleInterestTermsContractContract,
     ) => DebtOrder;
-    error: DebtKernelError;
+    error?: DebtKernelError;
     signatories: {
         debtor: boolean;
         creditor: boolean;

--- a/__test__/unit/blockchain_api/scenarios/index.ts
+++ b/__test__/unit/blockchain_api/scenarios/index.ts
@@ -1,4 +1,5 @@
 import { DebtKernelErrorScenario } from "./error_scenarios";
 import { INVALID_ORDERS } from "./invalid_orders";
+import { VALID_ORDERS } from "./valid_orders";
 
-export { DebtKernelErrorScenario, INVALID_ORDERS };
+export { DebtKernelErrorScenario, INVALID_ORDERS, VALID_ORDERS };

--- a/__test__/unit/blockchain_api/scenarios/valid_orders.ts
+++ b/__test__/unit/blockchain_api/scenarios/valid_orders.ts
@@ -1,0 +1,57 @@
+import * as Units from "utils/units";
+import * as moment from "moment";
+import { BigNumber } from "bignumber.js";
+import { ACCOUNTS } from "__test__/accounts";
+import { NULL_BYTES32, NULL_ADDRESS } from "utils/constants";
+
+import { DebtKernelError, DebtOrder } from "src/types";
+import {
+    DebtOrderWrapper,
+    DebtKernelContract,
+    RepaymentRouterContract,
+    DummyTokenContract,
+    SimpleInterestTermsContractContract,
+} from "src/wrappers";
+
+import { DebtKernelErrorScenario } from "./error_scenarios";
+
+export const VALID_ORDERS: DebtKernelErrorScenario[] = [
+    {
+        description: "order is valid",
+        generateDebtOrder: (
+            debtKernel: DebtKernelContract,
+            repaymentRouter: RepaymentRouterContract,
+            principalToken: DummyTokenContract,
+            termsContract: SimpleInterestTermsContractContract,
+        ) => {
+            return {
+                kernelVersion: debtKernel.address,
+                issuanceVersion: repaymentRouter.address,
+                principalAmount: Units.ether(1),
+                principalToken: principalToken.address,
+                debtor: ACCOUNTS[1].address,
+                debtorFee: Units.ether(0.001),
+                creditor: ACCOUNTS[2].address,
+                creditorFee: Units.ether(0.001),
+                relayer: ACCOUNTS[3].address,
+                relayerFee: Units.ether(0.001),
+                underwriter: ACCOUNTS[4].address,
+                underwriterFee: Units.ether(0.001),
+                underwriterRiskRating: Units.percent(0.001),
+                termsContract: termsContract.address,
+                termsContractParameters: NULL_BYTES32,
+                expirationTimestampInSec: new BigNumber(
+                    moment()
+                        .add(7, "days")
+                        .unix(),
+                ),
+                salt: new BigNumber(0),
+            };
+        },
+        signatories: {
+            debtor: true,
+            creditor: false,
+            underwriter: true,
+        },
+    },
+];

--- a/src/apis/blockchain_api.ts
+++ b/src/apis/blockchain_api.ts
@@ -44,10 +44,7 @@ export class BlockchainAPI {
      */
     public async getErrorLogs(txHash: string): Promise<string[]> {
         const receipt = await this.web3Utils.getTransactionReceiptAsync(txHash);
-        return _.flatMap(
-            ABIDecoder.decodeLogs(receipt.logs) as Logging.Entries,
-            DebtKernelError.parseErrors,
-        );
+        return DebtKernelError.parseLogs(ABIDecoder.decodeLogs(receipt.logs));
     }
 
     /**

--- a/src/types/debt_kernel_error.ts
+++ b/src/types/debt_kernel_error.ts
@@ -29,7 +29,19 @@ export enum DebtKernelError {
 }
 
 export namespace DebtKernelError {
-    export function parseErrors(entry: Logging.Entry): string[] {
+    export function parseLogs(logs: any[]): string[] {
+        return _.chain(logs)
+            .compact() // filter out any undefined values
+            .filter(isParseableEntry) // filter out any non-parseable entries
+            .flatMap(parseErrorsFromEntry) // parse out errors
+            .value();
+    }
+
+    function isParseableEntry(log: any): boolean {
+        return log.hasOwnProperty("name");
+    }
+
+    function parseErrorsFromEntry(entry: Logging.Entry): string[] {
         if (entry.name === LOG_ERROR_NAME) {
             const humanReadableErrorsOrNil = _.map(entry.events, parseErrorID);
             return _.compact(humanReadableErrorsOrNil);


### PR DESCRIPTION
This PR addresses the fact that our parsing of logs needs to handle scenarios where no errors are to be expected.

Our parsing code is now capable of handling such scenarios, with test cases to prove it. We can add more test cases as we encounter more scenarios.