### PR TITLE
feat: add getRepaymentScheduleAsync method on servicing API

### DIFF
--- a/__test__/integration/servicing_api/runners/get_repayment_schedule.ts
+++ b/__test__/integration/servicing_api/runners/get_repayment_schedule.ts
@@ -1,0 +1,117 @@
+// libraries
+import * as Web3 from "web3";
+import * as ABIDecoder from "abi-decoder";
+import { BigNumber } from "bignumber.js";
+
+// utils
+import * as Units from "utils/units";
+
+import { OrderAPI, ServicingAPI, SignerAPI, ContractsAPI, AdaptersAPI } from "src/apis";
+import { DebtOrder } from "src/types";
+import {
+    DebtOrderWrapper,
+    DummyTokenContract,
+    RepaymentRouterContract,
+    TokenTransferProxyContract,
+} from "src/wrappers";
+
+import { ACCOUNTS } from "../../../accounts";
+
+const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+
+const contractsApi = new ContractsAPI(web3);
+const orderApi = new OrderAPI(web3, contractsApi);
+const adaptersApi = new AdaptersAPI(web3, contractsApi);
+const signerApi = new SignerAPI(web3, contractsApi);
+const servicingApi = new ServicingAPI(web3, contractsApi);
+
+const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 400000 };
+
+import { GetRepaymentScheduleScenario } from "../scenarios/index";
+
+export class GetRepaymentScheduleRunner {
+    static testGetRepaymentScheduleScenario(scenario: GetRepaymentScheduleScenario) {
+        let principalToken: DummyTokenContract;
+        let tokenTransferProxy: TokenTransferProxyContract;
+        let repaymentRouter: RepaymentRouterContract;
+        let debtOrder: DebtOrder;
+        let issuanceHash: string;
+        let issuanceBlockTimestamp: BigNumber;
+
+        const CONTRACT_OWNER = ACCOUNTS[0].address;
+
+        const CREDITOR = ACCOUNTS[1].address;
+
+        const DEBTOR = ACCOUNTS[2].address;
+
+        beforeAll(async () => {
+            const tokenRegistry = await contractsApi.loadTokenRegistry();
+            const principalTokenAddress = await tokenRegistry.getTokenAddressBySymbol.callAsync(
+                "REP",
+            );
+            const repaymentRouter = await contractsApi.loadRepaymentRouterAsync();
+
+            tokenTransferProxy = await contractsApi.loadTokenTransferProxyAsync();
+            principalToken = await DummyTokenContract.at(principalTokenAddress, web3, TX_DEFAULTS);
+
+            // Grant creditor a balance of tokens
+            await principalToken.setBalance.sendTransactionAsync(CREDITOR, Units.ether(10), {
+                from: CONTRACT_OWNER,
+            });
+
+            // Grant debtor a balance of tokens
+            await principalToken.setBalance.sendTransactionAsync(DEBTOR, Units.ether(10), {
+                from: CONTRACT_OWNER,
+            });
+
+            // Approve the token transfer proxy for a sufficient
+            // amount of tokens for an order fill.
+            await principalToken.approve.sendTransactionAsync(
+                tokenTransferProxy.address,
+                Units.ether(10),
+                { from: CREDITOR },
+            );
+
+            debtOrder = await adaptersApi.simpleInterestLoan.toDebtOrder({
+                debtor: DEBTOR,
+                creditor: CREDITOR,
+                principalAmount: Units.ether(1),
+                principalToken: principalToken.address,
+                interestRate: new BigNumber(0.14),
+                amortizationUnit: scenario.amortizationUnit,
+                termLength: scenario.termLength,
+                // TODO: use snapshotting instead of rotating salts,
+                // this is a silly way of preventing clashes
+                salt: new BigNumber(Math.trunc(Math.random() * 10000)),
+            });
+
+            debtOrder.debtorSignature = await signerApi.asDebtor(debtOrder);
+
+            const debtOrderWrapped = await DebtOrderWrapper.applyNetworkDefaults(
+                debtOrder,
+                contractsApi,
+            );
+            issuanceHash = debtOrderWrapped.getIssuanceCommitmentHash();
+
+            await orderApi.fillAsync(debtOrder, { from: CREDITOR });
+
+            const debtRegistryEntry = await servicingApi.getDebtRegistryEntry(issuanceHash);
+            issuanceBlockTimestamp = debtRegistryEntry.issuanceBlockTimestamp;
+
+            ABIDecoder.addABI(repaymentRouter.abi);
+        });
+
+        afterAll(() => {
+            ABIDecoder.removeABI(repaymentRouter.abi);
+        });
+
+        describe(scenario.description, () => {
+            test(`returns the list: ${JSON.stringify(scenario.expected)}`, async () => {
+                const schedule = await servicingApi.getRepaymentScheduleAsync(issuanceHash);
+                const expected = scenario.expected(issuanceBlockTimestamp.toNumber());
+
+                expect(schedule).toEqual(expected);
+            });
+        });
+    }
+}

--- a/__test__/integration/servicing_api/scenarios/get_repayment_schedule.ts
+++ b/__test__/integration/servicing_api/scenarios/get_repayment_schedule.ts
@@ -1,0 +1,41 @@
+// libraries
+import { BigNumber } from "bignumber.js";
+
+import { GetRepaymentScheduleScenario } from "./";
+
+// Charta-based specifications for time.
+const hourInSeconds = 60 * 60;
+const dayInSeconds = 60 * 60 * 24;
+const weekInSeconds = 60 * 60 * 24 * 7;
+const monthInSeconds = 60 * 60 * 24 * 30;
+
+export const GET_REPAYMENT_SCHEDULE: GetRepaymentScheduleScenario[] = [
+    {
+        description: "for a schedule over 1 hour",
+        expected: (timestamp: number) => [timestamp + hourInSeconds],
+        amortizationUnit: "hours",
+        termLength: new BigNumber(1),
+    },
+    {
+        description: "for a schedule over 2 days",
+        expected: (timestamp: number) => [timestamp + dayInSeconds, timestamp + 2 * dayInSeconds],
+        amortizationUnit: "days",
+        termLength: new BigNumber(2),
+    },
+    {
+        description: "for a schedule over 2 weeks",
+        expected: (timestamp: number) => [timestamp + weekInSeconds, timestamp + 2 * weekInSeconds],
+        amortizationUnit: "weeks",
+        termLength: new BigNumber(2),
+    },
+    {
+        description: "for a schedule over 3 months",
+        expected: (timestamp: number) => [
+            timestamp + monthInSeconds,
+            timestamp + 2 * monthInSeconds,
+            timestamp + 3 * monthInSeconds,
+        ],
+        amortizationUnit: "months",
+        termLength: new BigNumber(3),
+    },
+];

--- a/__test__/integration/servicing_api/scenarios/index.ts
+++ b/__test__/integration/servicing_api/scenarios/index.ts
@@ -2,6 +2,7 @@ import { VALID_MAKE_REPAYMENT } from "./valid_make_repayment";
 import { INVALID_MAKE_REPAYMENT } from "./invalid_make_repayment";
 import { GET_VALUE_REPAID } from "./get_value_repaid";
 import { GET_EXPECTED_VALUE_REPAID } from "./get_expected_value_repaid";
+import { GET_REPAYMENT_SCHEDULE } from "./get_repayment_schedule";
 
 import { BigNumber } from "bignumber.js";
 
@@ -51,9 +52,19 @@ export interface GetExpectedValueRepaidScenario {
     expected: BigNumber;
 }
 
+export interface GetRepaymentScheduleScenario {
+    // The test's description.
+    description: string;
+    // Given a timestamp, returns a list of dates as unix timestamps.
+    expected: (timestamp: number) => Array<number>;
+    amortizationUnit: "hours" | "days" | "weeks" | "months" | "years";
+    termLength: BigNumber;
+}
+
 export {
     VALID_MAKE_REPAYMENT,
     INVALID_MAKE_REPAYMENT,
     GET_VALUE_REPAID,
     GET_EXPECTED_VALUE_REPAID,
+    GET_REPAYMENT_SCHEDULE,
 };

--- a/__test__/integration/servicing_api/servicing_api.spec.ts
+++ b/__test__/integration/servicing_api/servicing_api.spec.ts
@@ -2,6 +2,8 @@
 // in instances where we need our deployed artifacts in our test environment.
 jest.unmock("@dharmaprotocol/contracts");
 
+import { GET_REPAYMENT_SCHEDULE } from "./scenarios/get_repayment_schedule";
+
 // libraries
 import * as Web3 from "web3";
 
@@ -48,6 +50,10 @@ describe("Debt Servicing API (Integration Tests)", () => {
 
     describe("#getExpectedValueRepaid()", () => {
         GET_EXPECTED_VALUE_REPAID.forEach(scenarioRunner.testGetExpectedValueRepaidScenario);
+    });
+
+    describe("#getRepaymentSchedule", () => {
+        GET_REPAYMENT_SCHEDULE.forEach(scenarioRunner.testGetRepaymentScheduleScenario);
     });
 
     // TODO: Add tests for malformed TCP

--- a/__test__/integration/servicing_api/servicing_scenario_runner.ts
+++ b/__test__/integration/servicing_api/servicing_scenario_runner.ts
@@ -17,6 +17,7 @@ import { DebtKernelContract } from "src/wrappers/contract_wrappers/debt_kernel_w
 import { MakeRepaymentRunner } from "./runners/make_repayment";
 import { GetValueRepaidRunner } from "./runners/get_value_repaid";
 import { GetExpectedValueRepaidRunner } from "./runners/get_expected_value_repaid";
+import { GetRepaymentScheduleRunner } from "./runners/get_repayment_schedule";
 
 export class ServicingScenarioRunner {
     public web3Utils: Web3Utils;
@@ -27,6 +28,7 @@ export class ServicingScenarioRunner {
     public testMakeRepaymentScenario;
     public testGetValueRepaidScenario;
     public testGetExpectedValueRepaidScenario;
+    public testGetRepaymentScheduleScenario;
 
     private currentSnapshotId: number;
 
@@ -41,6 +43,9 @@ export class ServicingScenarioRunner {
             this,
         );
         this.testGetExpectedValueRepaidScenario = GetExpectedValueRepaidRunner.testGetExpectedValueRepaidScenario.bind(
+            this,
+        );
+        this.testGetRepaymentScheduleScenario = GetRepaymentScheduleRunner.testGetRepaymentScheduleScenario.bind(
             this,
         );
     }

--- a/__test__/unit/types/repayment_schedule.spec.ts
+++ b/__test__/unit/types/repayment_schedule.spec.ts
@@ -1,0 +1,87 @@
+// libraries
+import * as moment from "moment";
+
+// utils
+import { BigNumber } from "utils/bignumber";
+
+// types
+import { RepaymentSchedule } from "src/types/repayment_schedule";
+
+let amortizationUnit;
+let termLength;
+let issuanceDate;
+
+describe("RepaymentSchedule", () => {
+    describe("when the schedule is across 3 months, starting from March 19, 2018", () => {
+        beforeAll(() => {
+            termLength = 3;
+            amortizationUnit = "months";
+            issuanceDate = "2018-03-19";
+        });
+
+        describe("#toArray", () => {
+            test("should return an array of 3 timestamps in intervals of 30 days from March 19, 2018", () => {
+                const issuanceTime = moment(issuanceDate);
+
+                const schedule = new RepaymentSchedule(
+                    amortizationUnit,
+                    new BigNumber(termLength),
+                    issuanceTime.unix(),
+                );
+
+                expect(schedule.toArray()).toEqual([
+                    // A month is assumed to be 30 days by Charta, so the repayment dates
+                    // are expected to be exactly 30 days apart, starting from issuance time.
+                    issuanceTime.add(30, "days").unix(),
+                    issuanceTime.add(30, "days").unix(),
+                    issuanceTime.add(30, "days").unix(),
+                ]);
+            });
+        });
+
+        describe("when the schedule is across 1 month, starting from March 19, 2018", () => {
+            beforeAll(() => {
+                termLength = 1;
+                amortizationUnit = "months";
+                issuanceDate = "2018-03-19";
+            });
+
+            describe("#toArray", () => {
+                test("should return an array of 1 timestamp, 30 days from issuance time", () => {
+                    const issuanceTime = moment(issuanceDate);
+                    const schedule = new RepaymentSchedule(
+                        amortizationUnit,
+                        new BigNumber(termLength),
+                        issuanceTime.unix(),
+                    );
+
+                    expect(schedule.toArray()).toEqual([issuanceTime.add(30, "days").unix()]);
+                });
+            });
+        });
+    });
+
+    describe("when the schedule is across 2 years, starting from March 19, 2018", () => {
+        beforeAll(() => {
+            termLength = 2;
+            amortizationUnit = "years";
+            issuanceDate = "2018-02-28";
+        });
+
+        describe("#toArray", () => {
+            test("should return an array of 2 timestamps in intervals of 365 days from issuance time", () => {
+                const issuanceTime = moment(issuanceDate);
+                const schedule = new RepaymentSchedule(
+                    amortizationUnit,
+                    new BigNumber(termLength),
+                    issuanceTime.unix(),
+                );
+
+                expect(schedule.toArray()).toEqual([
+                    issuanceTime.add(365, "days").unix(),
+                    issuanceTime.add(365, "days").unix(),
+                ]);
+            });
+        });
+    });
+});

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -1,11 +1,18 @@
-import * as omit from "lodash.omit";
-import { DebtOrder } from "../types";
-import { ContractsAPI } from "../apis";
-import { BigNumber } from "../../utils/bignumber";
-import { NULL_ADDRESS } from "../../utils/constants";
-import { Assertions } from "../invariants";
+// libraries
 import * as Web3 from "web3";
 import * as singleLineString from "single-line-string";
+import * as omit from "lodash.omit";
+
+// utils
+import { BigNumber } from "../../utils/bignumber";
+import { NULL_ADDRESS } from "../../utils/constants";
+
+// types
+import { DebtOrder, RepaymentSchedule } from "../types";
+
+import { ContractsAPI } from "../apis";
+import { Assertions } from "../invariants";
+import { DebtRegistryEntry } from "../types/debt_registry_entry";
 
 export interface SimpleInterestLoanOrder extends DebtOrder {
     // Required Debt Order Parameters
@@ -241,6 +248,19 @@ export class SimpleInterestLoanAdapter {
             termLength,
             amortizationUnit,
         };
+    }
+
+    public getRepaymentSchedule(debtEntry: DebtRegistryEntry): Array<number> {
+        const { termsContractParameters, issuanceBlockTimestamp } = debtEntry;
+        const { termLength, amortizationUnit } = this.termsContractInterface.unpackParameters(
+            termsContractParameters,
+        );
+
+        return new RepaymentSchedule(
+            amortizationUnit,
+            termLength,
+            issuanceBlockTimestamp.toNumber(),
+        ).toArray();
     }
 
     private async assertTermsContractCorrespondsToPrincipalToken(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ import { DebtRegistryEntry, DebtRegistryEntryData } from "./debt_registry_entry"
 import { Logging } from "./logging";
 import { ErrorParser } from "./error_parser";
 import { DebtKernelError } from "./debt_kernel_error";
+import { RepaymentSchedule } from "./repayment_schedule";
 import { RepaymentRouterError } from "./repayment_router_error";
 
 export {
@@ -22,5 +23,6 @@ export {
     Logging,
     ErrorParser,
     DebtKernelError,
+    RepaymentSchedule,
     RepaymentRouterError,
 };

--- a/src/types/repayment_schedule.ts
+++ b/src/types/repayment_schedule.ts
@@ -1,0 +1,60 @@
+import { BigNumber } from "../../utils/bignumber";
+import * as map from "lodash.map";
+
+// The repayment schedule is calculated on basis of how charta computes it,
+// which simplifies the "months" unit as equal to 30 days.
+const AMORTIZATION_UNIT_TO_SECONDS = {
+    hours: 60 * 60,
+    days: 60 * 60 * 24,
+    weeks: 60 * 60 * 24 * 7,
+    months: 60 * 60 * 24 * 30,
+    years: 60 * 60 * 24 * 365,
+};
+
+/**
+ * Given an amortization unit, term length, and issuance date
+ * an instance of RepaymentSchedule can compute return a list of the dates for repayment.
+ *
+ * Examples:
+ *  // Setup
+ *  const currentTime = new BigNumber(Math.round(Date.now()/1000))
+ *  const termLength = new BigNumber(1)
+ *  const schedule = new RepaymentSchedule("months", termLength, currentTime)
+ *
+ *  // Usage
+ *  schedule.toArray()
+ *  => [1521506879]
+ */
+export class RepaymentSchedule {
+    private repaymentDates: Array<number>;
+
+    constructor(
+        private amortizationUnit: "hours" | "days" | "weeks" | "months" | "years",
+        private termLength: BigNumber,
+        private issuanceBlockTimestamp: number,
+    ) {
+        const repayments = new Array<number>(this.numRepaymentsToReturn());
+        const unitSeconds = this.unitInSeconds();
+
+        let timestamp = this.issuanceBlockTimestamp;
+
+        this.repaymentDates = map(repayments, () => (timestamp += unitSeconds));
+    }
+
+    /**
+     * Returns an array of dates (as unix timestamps) comprising the repayment schedule.
+     *
+     * @returns {Array<number>}
+     */
+    public toArray(): Array<number> {
+        return this.repaymentDates;
+    }
+
+    private numRepaymentsToReturn(): number {
+        return this.termLength.toNumber();
+    }
+
+    private unitInSeconds(): number {
+        return AMORTIZATION_UNIT_TO_SECONDS[this.amortizationUnit];
+    }
+}


### PR DESCRIPTION
- Adds `getRepaymentScheduleAsync`, which takes in an issuanceHash and returns a list of repayment dates, to servicing API. This method uses a new type, RepaymentSchedule, which is constructed from amortization unit, timestamp and term length. Its toArray() will return a list of timestamps, which is what is returned by the `getRepaymentScheduleAsync`.

Example usage:

```javascript
const list = await servicingApi.getRepaymentScheduleAsync(issuanceHash);
=> [1521592647, 1521597647] // unix timestamps for repayment schedule
```

TODO: This assumes that the adapter is always the SimpleInterestLoanAdapter. This is wrong to do. However, it's unclear what the best way is to figure out which adapter to use (and we only have the SILAdapter.)

I also think that some of the test setup in the runners can be cleaned up, but that's a separate PR.