### PR TITLE
fix: constructor signature for Assertions needs to be brought up to date

### DIFF
--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -58,8 +58,8 @@ const MAX_TERM_LENGTH_VALUE_HEX = "0xffffffffffffffffffffffffffffff";
 export class SimpleInterestLoanTerms {
     private assert: Assertions;
 
-    constructor(web3: Web3) {
-        this.assert = new Assertions(web3);
+    constructor(web3: Web3, contracts: ContractsAPI) {
+        this.assert = new Assertions(web3, contracts);
     }
 
     public packParameters(termsContractParameters: SimpleInterestTermsContractParameters): string {
@@ -161,9 +161,9 @@ export class SimpleInterestLoanAdapter {
     private termsContractInterface: SimpleInterestLoanTerms;
 
     public constructor(web3: Web3, contracts: ContractsAPI) {
-        this.assert = new Assertions(web3);
+        this.assert = new Assertions(web3, contracts);
         this.contracts = contracts;
-        this.termsContractInterface = new SimpleInterestLoanTerms(web3);
+        this.termsContractInterface = new SimpleInterestLoanTerms(web3, contracts);
     }
 
     /**

--- a/src/apis/blockchain_api.ts
+++ b/src/apis/blockchain_api.ts
@@ -27,7 +27,7 @@ export class BlockchainAPI {
     constructor(web3: Web3, contracts: ContractsAPI) {
         this.web3Utils = new Web3Utils(web3);
         this.intervalManager = new IntervalManager();
-        this.assert = new Assertions(web3);
+        this.assert = new Assertions(web3, contracts);
         this.contracts = contracts;
 
         // We need to configure the ABI Decoder in order to pull out relevant logs.

--- a/src/apis/signer_api.ts
+++ b/src/apis/signer_api.ts
@@ -27,7 +27,7 @@ export class SignerAPI {
     constructor(web3: Web3, contracts: ContractsAPI) {
         this.web3 = web3;
         this.contracts = contracts;
-        this.assert = new Assertions(this.web3);
+        this.assert = new Assertions(this.web3, this.contracts);
     }
 
     /**

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -27,7 +27,7 @@ export class TokenAPI {
     constructor(web3: Web3, contracts: ContractsAPI) {
         this.web3 = web3;
         this.contracts = contracts;
-        this.assert = new Assertions(this.web3);
+        this.assert = new Assertions(this.web3, this.contracts);
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,13 +326,6 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-"NonFungibleToken@git+https://github.com/dharmaprotocol/NonFungibleToken.git":
-  version "0.0.1"
-  resolved "git+https://github.com/dharmaprotocol/NonFungibleToken.git#162e8609569654630a5a5ef3bbbe5e0ebbe90f1d"
-  dependencies:
-    abi-decoder "^1.0.9"
-    zeppelin-solidity "^1.4.0"
-
 "NonFungibleToken@https://github.com/dharmaprotocol/NonFungibleToken.git":
   version "0.0.1"
   resolved "https://github.com/dharmaprotocol/NonFungibleToken.git#0044be43b2cb19e701a230e826ef5dd6a701215a"


### PR DESCRIPTION
This introduces the following changes:

- In several locations, the constructor for `Assertions` was missing its second argument.  This patches those instantiations.