### PR TITLE
fix: decouple applyNetworkDefaults from debt order wrapper

### DIFF
--- a/__test__/integration/order_api/order_scenario_runner.ts
+++ b/__test__/integration/order_api/order_scenario_runner.ts
@@ -43,7 +43,7 @@ export class OrderScenarioRunner {
 
     public testFillScenario(scenario: FillScenario) {
         describe(scenario.description, () => {
-            let debtOrder: DebtOrder;
+            let debtOrder: DebtOrder.Instance;
 
             beforeAll(() => {
                 ABIDecoder.addABI(this.debtKernel.abi);
@@ -109,6 +109,10 @@ export class OrderScenarioRunner {
 
                     const [debtOrderFilledLog] = compact(ABIDecoder.decodeLogs(receipt.logs));
 
+                    if (debtOrderFilledLog.name == "LogError") {
+                        console.log(debtOrderFilledLog);
+                    }
+
                     expect(debtOrderFilledLog.name).toBe("LogDebtOrderFilled");
                 });
             } else {
@@ -123,7 +127,7 @@ export class OrderScenarioRunner {
 
     public async testOrderCancelScenario(scenario: OrderCancellationScenario) {
         describe(scenario.description, () => {
-            let debtOrder: DebtOrder;
+            let debtOrder: DebtOrder.Instance;
 
             beforeAll(() => {
                 ABIDecoder.addABI(this.debtKernel.abi);
@@ -176,7 +180,7 @@ export class OrderScenarioRunner {
 
     public async testIssuanceCancelScenario(scenario: IssuanceCancellationScenario) {
         describe(scenario.description, () => {
-            let debtOrder: DebtOrder;
+            let debtOrder: DebtOrder.Instance;
 
             beforeAll(() => {
                 ABIDecoder.addABI(this.debtKernel.abi);

--- a/__test__/integration/order_api/order_scenario_runner.ts
+++ b/__test__/integration/order_api/order_scenario_runner.ts
@@ -109,10 +109,6 @@ export class OrderScenarioRunner {
 
                     const [debtOrderFilledLog] = compact(ABIDecoder.decodeLogs(receipt.logs));
 
-                    if (debtOrderFilledLog.name == "LogError") {
-                        console.log(debtOrderFilledLog);
-                    }
-
                     expect(debtOrderFilledLog.name).toBe("LogDebtOrderFilled");
                 });
             } else {

--- a/__test__/integration/order_api/scenarios/index.ts
+++ b/__test__/integration/order_api/scenarios/index.ts
@@ -37,7 +37,7 @@ export interface FillScenario {
     creditorAllowance?: BigNumber;
     errorType?: string;
     errorMessage?: string;
-    beforeBlock?: (debtOrder: DebtOrder, debtKernel: DebtKernelContract) => Promise<any>;
+    beforeBlock?: (debtOrder: DebtOrder.Instance, debtKernel: DebtKernelContract) => Promise<any>;
 }
 
 export interface OrderCancellationScenario {

--- a/__test__/integration/order_api/scenarios/invalid_orders.ts
+++ b/__test__/integration/order_api/scenarios/invalid_orders.ts
@@ -267,7 +267,7 @@ export const INVALID_ORDERS: FillScenario[] = [
         successfullyFills: false,
         errorType: "DEBT_ORDER_CANCELLED",
         errorMessage: OrderAPIErrors.ORDER_CANCELLED(),
-        beforeBlock: async (debtOrder: DebtOrder, debtKernel: DebtKernelContract) => {
+        beforeBlock: async (debtOrder: DebtOrder.Instance, debtKernel: DebtKernelContract) => {
             const debtOrderWrapper = new DebtOrderWrapper(debtOrder);
 
             await debtKernel.cancelDebtOrder.sendTransactionAsync(
@@ -319,7 +319,7 @@ export const INVALID_ORDERS: FillScenario[] = [
         successfullyFills: false,
         errorType: "DEBT_ORDER_ALREADY_FILLED",
         errorMessage: OrderAPIErrors.DEBT_ORDER_ALREADY_FILLED(),
-        beforeBlock: async (debtOrder: DebtOrder, debtKernel: DebtKernelContract) => {
+        beforeBlock: async (debtOrder: DebtOrder.Instance, debtKernel: DebtKernelContract) => {
             const debtOrderWrapped = new DebtOrderWrapper(debtOrder);
 
             await debtKernel.fillDebtOrder.sendTransactionAsync(

--- a/__test__/integration/servicing_api/runners/get_expected_value_repaid.ts
+++ b/__test__/integration/servicing_api/runners/get_expected_value_repaid.ts
@@ -36,7 +36,7 @@ export class GetExpectedValueRepaidRunner {
         let nonPrincipalToken: DummyTokenContract;
         let tokenTransferProxy: TokenTransferProxyContract;
         let repaymentRouter: RepaymentRouterContract;
-        let debtOrder: DebtOrder;
+        let debtOrder: DebtOrder.Instance;
         let issuanceHash: string;
 
         const CONTRACT_OWNER = ACCOUNTS[0].address;
@@ -96,11 +96,7 @@ export class GetExpectedValueRepaidRunner {
 
             debtOrder.debtorSignature = await signerApi.asDebtor(debtOrder);
 
-            const debtOrderWrapped = await DebtOrderWrapper.applyNetworkDefaults(
-                debtOrder,
-                contractsApi,
-            );
-            issuanceHash = debtOrderWrapped.getIssuanceCommitmentHash();
+            issuanceHash = await orderApi.getIssuanceHash(debtOrder);
 
             await orderApi.fillAsync(debtOrder, { from: CREDITOR });
 

--- a/__test__/integration/servicing_api/runners/get_value_repaid.ts
+++ b/__test__/integration/servicing_api/runners/get_value_repaid.ts
@@ -35,7 +35,7 @@ export class GetValueRepaidRunner {
         let nonPrincipalToken: DummyTokenContract;
         let tokenTransferProxy: TokenTransferProxyContract;
         let repaymentRouter: RepaymentRouterContract;
-        let debtOrder: DebtOrder;
+        let debtOrder: DebtOrder.Instance;
         let issuanceHash: string;
 
         const CONTRACT_OWNER = ACCOUNTS[0].address;
@@ -100,11 +100,7 @@ export class GetValueRepaidRunner {
 
             debtOrder.debtorSignature = await signerApi.asDebtor(debtOrder);
 
-            const debtOrderWrapped = await DebtOrderWrapper.applyNetworkDefaults(
-                debtOrder,
-                contractsApi,
-            );
-            issuanceHash = debtOrderWrapped.getIssuanceCommitmentHash();
+            issuanceHash = await orderApi.getIssuanceHash(debtOrder);
 
             await orderApi.fillAsync(debtOrder, { from: CREDITOR });
 

--- a/__test__/integration/servicing_api/runners/make_repayment.ts
+++ b/__test__/integration/servicing_api/runners/make_repayment.ts
@@ -36,7 +36,7 @@ export class MakeRepaymentRunner {
             let principalToken: DummyTokenContract;
             let nonPrincipalToken: DummyTokenContract;
             let tokenTransferProxy: TokenTransferProxyContract;
-            let debtOrder: DebtOrder;
+            let debtOrder: DebtOrder.Instance;
             let issuanceHash: string;
 
             const CONTRACT_OWNER = ACCOUNTS[0].address;
@@ -114,11 +114,7 @@ export class MakeRepaymentRunner {
 
                 debtOrder.debtorSignature = await signerApi.asDebtor(debtOrder);
 
-                const debtOrderWrapped = await DebtOrderWrapper.applyNetworkDefaults(
-                    debtOrder,
-                    contractsApi,
-                );
-                issuanceHash = debtOrderWrapped.getIssuanceCommitmentHash();
+                issuanceHash = await orderApi.getIssuanceHash(debtOrder);
 
                 await orderApi.fillAsync(debtOrder, { from: CREDITOR });
 

--- a/__test__/unit/blockchain_api/scenarios/error_scenarios.ts
+++ b/__test__/unit/blockchain_api/scenarios/error_scenarios.ts
@@ -24,7 +24,7 @@ export interface DebtKernelErrorScenario {
     };
     creditorBalance?: BigNumber;
     creditorAllowance?: BigNumber;
-    beforeBlock?: (debtOrder: DebtOrder, debtKernel: DebtKernelContract) => Promise<any>;
+    beforeBlock?: (debtOrder: DebtOrder.Instance, debtKernel: DebtKernelContract) => Promise<any>;
 }
 
 export interface RepaymentRouterErrorScenario {

--- a/__test__/unit/blockchain_api/scenarios/invalid_orders.ts
+++ b/__test__/unit/blockchain_api/scenarios/invalid_orders.ts
@@ -328,7 +328,7 @@ export const INVALID_ORDERS: DebtKernelErrorScenario[] = [
             creditor: false,
             underwriter: true,
         },
-        beforeBlock: async (debtOrder: DebtOrder, debtKernel: DebtKernelContract) => {
+        beforeBlock: async (debtOrder: DebtOrder.Instance, debtKernel: DebtKernelContract) => {
             const debtOrderWrapper = new DebtOrderWrapper(debtOrder);
 
             await debtKernel.cancelDebtOrder.sendTransactionAsync(
@@ -377,7 +377,7 @@ export const INVALID_ORDERS: DebtKernelErrorScenario[] = [
             creditor: false,
             underwriter: true,
         },
-        beforeBlock: async (debtOrder: DebtOrder, debtKernel: DebtKernelContract) => {
+        beforeBlock: async (debtOrder: DebtOrder.Instance, debtKernel: DebtKernelContract) => {
             const debtOrderWrapped = new DebtOrderWrapper(debtOrder);
 
             return await debtKernel.fillDebtOrder.sendTransactionAsync(
@@ -430,7 +430,7 @@ export const INVALID_ORDERS: DebtKernelErrorScenario[] = [
             creditor: false,
             underwriter: true,
         },
-        beforeBlock: async (debtOrder: DebtOrder, debtKernel: DebtKernelContract) => {
+        beforeBlock: async (debtOrder: DebtOrder.Instance, debtKernel: DebtKernelContract) => {
             return await debtKernel.cancelIssuance.sendTransactionAsync(
                 debtOrder.issuanceVersion,
                 debtOrder.debtor,

--- a/__test__/unit/debt_order_wrapper.spec.ts
+++ b/__test__/unit/debt_order_wrapper.spec.ts
@@ -7,7 +7,7 @@ import { Web3Utils } from "utils/web3_utils";
 
 import { ACCOUNTS } from "../accounts";
 
-let debtOrderWrapper: DebtOrderWrapper;
+let debtOrderWrapper: DebtOrder.InstanceWrapper;
 
 // For the unit test's purposes, we use arbitrary
 // addresses for all debt order fields that expect addresses.

--- a/src/adapters/base_adapter.ts
+++ b/src/adapters/base_adapter.ts
@@ -1,6 +1,6 @@
 import { DebtOrder } from "../types";
 
 export abstract class BaseAdapter {
-    public abstract async generateAsync(params: object): Promise<DebtOrder>;
-    public abstract async validateAsync(debtOrder: DebtOrder): Promise<void>;
+    public abstract async generateAsync(params: object): Promise<DebtOrder.Instance>;
+    public abstract async validateAsync(debtOrder: DebtOrder.Instance): Promise<void>;
 }

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -7,7 +7,7 @@ import { Assertions } from "../invariants";
 import * as Web3 from "web3";
 import * as singleLineString from "single-line-string";
 
-export interface SimpleInterestLoanOrder extends DebtOrder {
+export interface SimpleInterestLoanOrder extends DebtOrder.Instance {
     // Required Debt Order Parameters
     principalAmount: BigNumber;
     principalToken: string;
@@ -173,7 +173,9 @@ export class SimpleInterestLoanAdapter {
      * @param  simpleInterestLoanOrder a simple interest loan order instance.
      * @return                         the generated Dharma debt order.
      */
-    public async toDebtOrder(simpleInterestLoanOrder: SimpleInterestLoanOrder): Promise<DebtOrder> {
+    public async toDebtOrder(
+        simpleInterestLoanOrder: SimpleInterestLoanOrder,
+    ): Promise<DebtOrder.Instance> {
         this.assert.schema.simpleInterestLoanOrder(
             "simpleInterestLoanOrder",
             simpleInterestLoanOrder,
@@ -187,7 +189,7 @@ export class SimpleInterestLoanAdapter {
             termLength,
         } = simpleInterestLoanOrder;
 
-        let debtOrder: DebtOrder = omit(simpleInterestLoanOrder, [
+        let debtOrder: DebtOrder.Instance = omit(simpleInterestLoanOrder, [
             "interestRate",
             "amortizationUnit",
             "termLength",
@@ -217,7 +219,7 @@ export class SimpleInterestLoanAdapter {
      * @param  debtOrder a Dharma debt order instance.
      * @return           the generated simple interest loan order.
      */
-    public async fromDebtOrder(debtOrder: DebtOrder): Promise<SimpleInterestLoanOrder> {
+    public async fromDebtOrder(debtOrder: DebtOrder.Instance): Promise<SimpleInterestLoanOrder> {
         this.assert.schema.debtOrderWithTermsSpecified("debtOrder", debtOrder);
         await this.assertTermsContractCorrespondsToPrincipalToken(
             debtOrder.principalToken,

--- a/src/apis/signer_api.ts
+++ b/src/apis/signer_api.ts
@@ -39,13 +39,12 @@ export class SignerAPI {
      * @param debtOrder The debt order for which we desire a signature
      * @return The ECDSA signature of the debt order's debtor commitment hash
      */
-    async asDebtor(debtOrder: DebtOrder): Promise<ECDSASignature> {
+    async asDebtor(debtOrder: DebtOrder.Instance): Promise<ECDSASignature> {
         this.assert.schema.debtOrderWithTermsAndDebtorSpecified("debtOrder", debtOrder);
 
-        const wrappedDebtOrder = await DebtOrderWrapper.applyNetworkDefaults(
-            debtOrder,
-            this.contracts,
-        );
+        debtOrder = await DebtOrder.applyNetworkDefaults(debtOrder, this.contracts);
+
+        const wrappedDebtOrder = new DebtOrderWrapper(debtOrder);
 
         return this.signPayloadWithAddress(
             wrappedDebtOrder.getDebtorCommitmentHash(),
@@ -62,13 +61,12 @@ export class SignerAPI {
      * @param debtOrder The debt order for which we desire a signature
      * @return The ECDSA signature of the debt order's debtor commitment hash
      */
-    async asCreditor(debtOrder: DebtOrder): Promise<ECDSASignature> {
+    async asCreditor(debtOrder: DebtOrder.Instance): Promise<ECDSASignature> {
         this.assert.schema.debtOrderWithTermsDebtorAndCreditorSpecified("debtOrder", debtOrder);
 
-        const wrappedDebtOrder = await DebtOrderWrapper.applyNetworkDefaults(
-            debtOrder,
-            this.contracts,
-        );
+        debtOrder = await DebtOrder.applyNetworkDefaults(debtOrder, this.contracts);
+
+        const wrappedDebtOrder = new DebtOrderWrapper(debtOrder);
 
         return this.signPayloadWithAddress(
             wrappedDebtOrder.getCreditorCommitmentHash(),
@@ -85,13 +83,12 @@ export class SignerAPI {
      * @param debtOrder The debt order for which we desire a signature
      * @return The ECDSA signature of the debt order's debtor commitment hash
      */
-    async asUnderwriter(debtOrder: DebtOrder): Promise<ECDSASignature> {
+    async asUnderwriter(debtOrder: DebtOrder.Instance): Promise<ECDSASignature> {
         this.assert.schema.debtOrderWithTermsAndDebtorSpecified("debtOrder", debtOrder);
 
-        const wrappedDebtOrder = await DebtOrderWrapper.applyNetworkDefaults(
-            debtOrder,
-            this.contracts,
-        );
+        debtOrder = await DebtOrder.applyNetworkDefaults(debtOrder, this.contracts);
+
+        const wrappedDebtOrder = new DebtOrderWrapper(debtOrder);
 
         return this.signPayloadWithAddress(
             wrappedDebtOrder.getUnderwriterCommitmentHash(),

--- a/src/types/debt_order.ts
+++ b/src/types/debt_order.ts
@@ -1,27 +1,81 @@
+// external
 import { BigNumber } from "../../utils/bignumber";
+import * as moment from "moment";
+import * as assignDefaults from "lodash.defaults";
+
+// apis
+import { ContractsAPI } from "../apis/";
+
+// utils
+import { NULL_ADDRESS, NULL_BYTES32, NULL_ECDSA_SIGNATURE } from "../../utils/constants";
 import { ECDSASignature } from "./ecdsa_signature";
 
-export interface DebtOrder {
-    kernelVersion?: string;
-    issuanceVersion?: string;
-    principalAmount?: BigNumber;
-    principalToken?: string;
-    debtor?: string;
-    debtorFee?: BigNumber;
-    creditor?: string;
-    creditorFee?: BigNumber;
-    relayer?: string;
-    relayerFee?: BigNumber;
-    underwriter?: string;
-    underwriterFee?: BigNumber;
-    underwriterRiskRating?: BigNumber;
-    termsContract?: string;
-    termsContractParameters?: string;
-    expirationTimestampInSec?: BigNumber;
-    salt?: BigNumber;
+export namespace DebtOrder {
+    export const DEFAULTS = {
+        kernelVersion: NULL_ADDRESS,
+        issuanceVersion: NULL_ADDRESS,
+        principalAmount: new BigNumber(0),
+        principalToken: NULL_ADDRESS,
+        debtor: NULL_ADDRESS,
+        debtorFee: new BigNumber(0),
+        creditor: NULL_ADDRESS,
+        creditorFee: new BigNumber(0),
+        relayer: NULL_ADDRESS,
+        relayerFee: new BigNumber(0),
+        underwriter: NULL_ADDRESS,
+        underwriterFee: new BigNumber(0),
+        underwriterRiskRating: new BigNumber(0),
+        termsContract: NULL_ADDRESS,
+        termsContractParameters: NULL_BYTES32,
+        expirationTimestampInSec: new BigNumber(
+            moment()
+                .add(30, "days")
+                .unix(),
+        ),
+        salt: new BigNumber(0),
+        debtorSignature: NULL_ECDSA_SIGNATURE,
+        creditorSignature: NULL_ECDSA_SIGNATURE,
+        underWriterSignature: NULL_ECDSA_SIGNATURE,
+    };
 
-    // Signatures
-    debtorSignature?: ECDSASignature;
-    creditorSignature?: ECDSASignature;
-    underwriterSignature?: ECDSASignature;
+    export interface Instance {
+        kernelVersion?: string;
+        issuanceVersion?: string;
+        principalAmount?: BigNumber;
+        principalToken?: string;
+        debtor?: string;
+        debtorFee?: BigNumber;
+        creditor?: string;
+        creditorFee?: BigNumber;
+        relayer?: string;
+        relayerFee?: BigNumber;
+        underwriter?: string;
+        underwriterFee?: BigNumber;
+        underwriterRiskRating?: BigNumber;
+        termsContract?: string;
+        termsContractParameters?: string;
+        expirationTimestampInSec?: BigNumber;
+        salt?: BigNumber;
+
+        // Signatures
+        debtorSignature?: ECDSASignature;
+        creditorSignature?: ECDSASignature;
+        underwriterSignature?: ECDSASignature;
+    }
+
+    export async function applyNetworkDefaults(
+        debtOrder: Instance,
+        contracts: ContractsAPI,
+    ): Promise<Instance> {
+        const debtKernel = await contracts.loadDebtKernelAsync();
+        const repaymentRouter = await contracts.loadRepaymentRouterAsync();
+
+        const networkDefaults = {
+            ...DEFAULTS,
+            kernelVersion: debtKernel.address,
+            issuanceVersion: repaymentRouter.address,
+        };
+
+        return assignDefaults(debtOrder, networkDefaults);
+    }
 }

--- a/src/wrappers/debt_order_wrapper.ts
+++ b/src/wrappers/debt_order_wrapper.ts
@@ -1,60 +1,15 @@
+// external
 import { BigNumber } from "../../utils/bignumber";
-import { ECDSASignature, DebtOrder, IssuanceCommitment } from "../types";
-import { Web3Utils } from "../../utils/web3_utils";
-import { NULL_ADDRESS, NULL_BYTES32, NULL_ECDSA_SIGNATURE } from "../../utils/constants";
-import { ContractsAPI } from "../apis";
-import * as moment from "moment";
-import * as assignDefaults from "lodash.defaults";
 
-const DEFAULTS = {
-    kernelVersion: NULL_ADDRESS,
-    issuanceVersion: NULL_ADDRESS,
-    principalAmount: new BigNumber(0),
-    principalToken: NULL_ADDRESS,
-    debtor: NULL_ADDRESS,
-    debtorFee: new BigNumber(0),
-    creditor: NULL_ADDRESS,
-    creditorFee: new BigNumber(0),
-    relayer: NULL_ADDRESS,
-    relayerFee: new BigNumber(0),
-    underwriter: NULL_ADDRESS,
-    underwriterFee: new BigNumber(0),
-    underwriterRiskRating: new BigNumber(0),
-    termsContract: NULL_ADDRESS,
-    termsContractParameters: NULL_BYTES32,
-    expirationTimestampInSec: new BigNumber(
-        moment()
-            .add(30, "days")
-            .unix(),
-    ),
-    salt: new BigNumber(0),
-    debtorSignature: NULL_ECDSA_SIGNATURE,
-    creditorSignature: NULL_ECDSA_SIGNATURE,
-    underWriterSignature: NULL_ECDSA_SIGNATURE,
-};
+// types
+import { ECDSASignature, DebtOrder, IssuanceCommitment } from "../types";
+
+// utils
+import { Web3Utils } from "../../utils/web3_utils";
+import { NULL_ECDSA_SIGNATURE } from "../../utils/constants";
 
 export class DebtOrderWrapper {
-    private debtOrder: DebtOrder;
-
-    constructor(debtOrder: DebtOrder) {
-        this.debtOrder = Object.assign({}, debtOrder);
-
-        assignDefaults(this.debtOrder, DEFAULTS);
-    }
-
-    public static async applyNetworkDefaults(
-        debtOrder: DebtOrder,
-        contracts: ContractsAPI,
-    ): Promise<DebtOrderWrapper> {
-        const debtKernel = await contracts.loadDebtKernelAsync();
-        const repaymentRouter = await contracts.loadRepaymentRouterAsync();
-
-        return new DebtOrderWrapper({
-            kernelVersion: debtOrder.kernelVersion || debtKernel.address,
-            issuanceVersion: debtOrder.issuanceVersion || repaymentRouter.address,
-            ...debtOrder,
-        });
-    }
+    constructor(private debtOrder: DebtOrder.Instance) {}
 
     public getCreditor(): string {
         return this.debtOrder.creditor;
@@ -222,7 +177,7 @@ export class DebtOrderWrapper {
      * Getters
      */
 
-    public getDebtOrder(): DebtOrder {
+    public getDebtOrder(): DebtOrder.Instance {
         return this.debtOrder;
     }
 


### PR DESCRIPTION
This introduces the following changes:

- It was a bit messy for us to have to go through `DebtOrderWrapper` any time we wanted to apply network defaults (i.e. DebtKernel address, etc.) to the debt order, especially if we wanted a DebtOrder type in return, as opposed to a `DebtOrderWrapper`.   This PR decouples applyNetworkDefaults into a namespace of DebtOrder specific functions.
- Fixes tests and functionality that depended on `applyNetworkDefaults`