### PR TITLE
SimpleInterestLoanAdapter should apply network defaults to debt orders it generates

### DIFF
--- a/__test__/integration/servicing_api/runners/get_repayment_schedule.ts
+++ b/__test__/integration/servicing_api/runners/get_repayment_schedule.ts
@@ -87,11 +87,7 @@ export class GetRepaymentScheduleRunner {
 
             debtOrder.debtorSignature = await signerApi.asDebtor(debtOrder);
 
-            const debtOrderWrapped = await DebtOrderWrapper.applyNetworkDefaults(
-                debtOrder,
-                contractsApi,
-            );
-            issuanceHash = debtOrderWrapped.getIssuanceCommitmentHash();
+            issuanceHash = await orderApi.getIssuanceHash(debtOrder);
 
             await orderApi.fillAsync(debtOrder, { from: CREDITOR });
 

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -216,7 +216,7 @@ export class SimpleInterestLoanAdapter {
             termLength,
         });
 
-        return debtOrder;
+        return DebtOrder.applyNetworkDefaults(debtOrder, this.contracts);
     }
 
     /**


### PR DESCRIPTION
This PR introduces the following changes:

- The `toDebtOrder` method in `SimpleInterestLoanAdapter` was previously only returning a subset of the full debt order fields.  We use the `applyNetworkDefaults` method to attach default values for the debt kernel / repayment router's addresses to the debt order returned by `toDebtOrder`.  This should hopefully resolve issues we are seeing in Bazaar related to mismatching signatures.
- Add tests for the above
- Path a failing tests in get_repayment_schedule