### PR TITLE
Add getDebtsAsync and getInvestmentsAsync endpoints to servicing api

### DIFF
--- a/__test__/integration/servicing_api/runners/get_debts.ts
+++ b/__test__/integration/servicing_api/runners/get_debts.ts
@@ -64,7 +64,7 @@ export class GetDebtsRunner {
                         interestRate: new BigNumber(0.1),
                         amortizationUnit: "months",
                         termLength: new BigNumber(2),
-                        salt: new BigNumber(i),
+                        salt: new BigNumber(Math.trunc(Math.random() * 10000)),
                     });
 
                     debtOrder.debtorSignature = await signerApi.asDebtor(debtOrder);

--- a/__test__/integration/servicing_api/scenarios/get_debts.ts
+++ b/__test__/integration/servicing_api/scenarios/get_debts.ts
@@ -32,6 +32,6 @@ export const GET_DEBTS: GetDebtsScenario[] = [
         debtor: ACCOUNTS[4].address,
         account: "0x122341",
         numDebtAgreements: 0,
-        errorMessage: "Hello, world!",
+        errorMessage: "Expected account to conform to schema /Address",
     },
 ];

--- a/__test__/integration/servicing_api/scenarios/get_debts.ts
+++ b/__test__/integration/servicing_api/scenarios/get_debts.ts
@@ -1,0 +1,37 @@
+import { ACCOUNTS } from "../../../accounts";
+
+import { GetDebtsScenario } from "./";
+
+export const GET_DEBTS: GetDebtsScenario[] = [
+    {
+        description: "no debts associated with user",
+        debtor: ACCOUNTS[4].address,
+        account: ACCOUNTS[4].address,
+        numDebtAgreements: 0,
+    },
+    {
+        description: "one debt associated with user",
+        debtor: ACCOUNTS[4].address,
+        account: ACCOUNTS[4].address,
+        numDebtAgreements: 1,
+    },
+    {
+        description: "three debts associated with user",
+        debtor: ACCOUNTS[4].address,
+        account: ACCOUNTS[4].address,
+        numDebtAgreements: 3,
+    },
+    {
+        description: "5 debts associated with user",
+        debtor: ACCOUNTS[4].address,
+        account: ACCOUNTS[4].address,
+        numDebtAgreements: 5,
+    },
+    {
+        description: "invalid address passed into account argument",
+        debtor: ACCOUNTS[4].address,
+        account: "0x122341",
+        numDebtAgreements: 0,
+        errorMessage: "Hello, world!",
+    },
+];

--- a/__test__/integration/servicing_api/scenarios/get_investments.ts
+++ b/__test__/integration/servicing_api/scenarios/get_investments.ts
@@ -1,0 +1,37 @@
+import { ACCOUNTS } from "../../../accounts";
+
+import { GetInvestmentsScenario } from "./";
+
+export const GET_INVESTMENTS: GetInvestmentsScenario[] = [
+    {
+        description: "no investments associated with user",
+        creditor: ACCOUNTS[5].address,
+        account: ACCOUNTS[5].address,
+        numInvestments: 0,
+    },
+    {
+        description: "one investment associated with user",
+        creditor: ACCOUNTS[5].address,
+        account: ACCOUNTS[5].address,
+        numInvestments: 1,
+    },
+    {
+        description: "three investments associated with user",
+        creditor: ACCOUNTS[5].address,
+        account: ACCOUNTS[5].address,
+        numInvestments: 3,
+    },
+    {
+        description: "5 debts associated with user",
+        creditor: ACCOUNTS[5].address,
+        account: ACCOUNTS[5].address,
+        numInvestments: 5,
+    },
+    {
+        description: "invalid address passed into account argument",
+        creditor: ACCOUNTS[5].address,
+        account: "0x122341",
+        numInvestments: 0,
+        errorMessage: "Expected account to conform to schema /Address",
+    },
+];

--- a/__test__/integration/servicing_api/scenarios/index.ts
+++ b/__test__/integration/servicing_api/scenarios/index.ts
@@ -4,6 +4,7 @@ import { GET_VALUE_REPAID } from "./get_value_repaid";
 import { GET_EXPECTED_VALUE_REPAID } from "./get_expected_value_repaid";
 import { GET_REPAYMENT_SCHEDULE } from "./get_repayment_schedule";
 import { GET_DEBTS } from "./get_debts";
+import { GET_INVESTMENTS } from "./get_investments";
 
 import { BigNumber } from "bignumber.js";
 
@@ -75,6 +76,19 @@ export interface GetDebtsScenario {
     errorMessage?: string;
 }
 
+export interface GetInvestmentsScenario {
+    // The test's description.
+    description: string;
+    // Specifies the account we'll be pulling investments for
+    account: string;
+    // Specifies the account on whose behalf we'll be filling loan orders
+    creditor: string;
+    // Number of debt agreements the account has invested in.
+    numInvestments: number;
+    // If the test fails, this field will contain the expected error message
+    errorMessage?: string;
+}
+
 export {
     VALID_MAKE_REPAYMENT,
     INVALID_MAKE_REPAYMENT,
@@ -82,4 +96,5 @@ export {
     GET_EXPECTED_VALUE_REPAID,
     GET_REPAYMENT_SCHEDULE,
     GET_DEBTS,
+    GET_INVESTMENTS,
 };

--- a/__test__/integration/servicing_api/scenarios/index.ts
+++ b/__test__/integration/servicing_api/scenarios/index.ts
@@ -3,6 +3,7 @@ import { INVALID_MAKE_REPAYMENT } from "./invalid_make_repayment";
 import { GET_VALUE_REPAID } from "./get_value_repaid";
 import { GET_EXPECTED_VALUE_REPAID } from "./get_expected_value_repaid";
 import { GET_REPAYMENT_SCHEDULE } from "./get_repayment_schedule";
+import { GET_DEBTS } from "./get_debts";
 
 import { BigNumber } from "bignumber.js";
 
@@ -61,10 +62,24 @@ export interface GetRepaymentScheduleScenario {
     termLength: BigNumber;
 }
 
+export interface GetDebtsScenario {
+    // The test's description.
+    description: string;
+    // Specifies the account we'll be pulling debts for
+    account: string;
+    // Specifies the account on whose behalf we'll be taking out loans
+    debtor: string;
+    // Number of debt agreements the account is engaged in.
+    numDebtAgreements: number;
+    // If the test fails, this field will contain the expected error message
+    errorMessage?: string;
+}
+
 export {
     VALID_MAKE_REPAYMENT,
     INVALID_MAKE_REPAYMENT,
     GET_VALUE_REPAID,
     GET_EXPECTED_VALUE_REPAID,
     GET_REPAYMENT_SCHEDULE,
+    GET_DEBTS,
 };

--- a/__test__/integration/servicing_api/servicing_api.spec.ts
+++ b/__test__/integration/servicing_api/servicing_api.spec.ts
@@ -14,6 +14,7 @@ import {
     GET_VALUE_REPAID,
     GET_EXPECTED_VALUE_REPAID,
     GET_DEBTS,
+    GET_INVESTMENTS,
 } from "./scenarios";
 
 // scenario runner
@@ -52,6 +53,10 @@ describe("Debt Servicing API (Integration Tests)", () => {
 
     describe("#getDebtsAsync()", () => {
         GET_DEBTS.forEach(scenarioRunner.testGetDebtsScenario);
+    });
+
+    describe("#getInvestmentsAsync()", () => {
+        GET_INVESTMENTS.forEach(scenarioRunner.testGetInvestmentsScenario);
     });
 
     // TODO: Add tests for malformed TCP

--- a/__test__/integration/servicing_api/servicing_api.spec.ts
+++ b/__test__/integration/servicing_api/servicing_api.spec.ts
@@ -7,22 +7,16 @@ import { GET_REPAYMENT_SCHEDULE } from "./scenarios/get_repayment_schedule";
 // libraries
 import * as Web3 from "web3";
 
-import { OrderAPI, ServicingAPI, SignerAPI, ContractsAPI, AdaptersAPI } from "src/apis";
-import { DebtOrder } from "src/types";
-import {
-    DebtOrderWrapper,
-    DummyTokenContract,
-    RepaymentRouterContract,
-    TokenTransferProxyContract,
-} from "src/wrappers";
-
+// scenarios
 import {
     VALID_MAKE_REPAYMENT,
     INVALID_MAKE_REPAYMENT,
     GET_VALUE_REPAID,
     GET_EXPECTED_VALUE_REPAID,
+    GET_DEBTS,
 } from "./scenarios";
 
+// scenario runner
 import { ServicingScenarioRunner } from "./servicing_scenario_runner";
 
 const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
@@ -54,6 +48,10 @@ describe("Debt Servicing API (Integration Tests)", () => {
 
     describe("#getRepaymentSchedule", () => {
         GET_REPAYMENT_SCHEDULE.forEach(scenarioRunner.testGetRepaymentScheduleScenario);
+    });
+
+    describe("#getDebtsAsync()", () => {
+        GET_DEBTS.forEach(scenarioRunner.testGetDebtsScenario);
     });
 
     // TODO: Add tests for malformed TCP

--- a/__test__/integration/servicing_api/servicing_scenario_runner.ts
+++ b/__test__/integration/servicing_api/servicing_scenario_runner.ts
@@ -10,6 +10,7 @@ import { GetValueRepaidRunner } from "./runners/get_value_repaid";
 import { GetExpectedValueRepaidRunner } from "./runners/get_expected_value_repaid";
 import { GetRepaymentScheduleRunner } from "./runners/get_repayment_schedule";
 import { GetDebtsRunner } from "./runners/get_debts";
+import { GetInvestmentsRunner } from "./runners/get_investments";
 
 export class ServicingScenarioRunner {
     public web3Utils: Web3Utils;
@@ -19,6 +20,7 @@ export class ServicingScenarioRunner {
     public testGetExpectedValueRepaidScenario;
     public testGetRepaymentScheduleScenario;
     public testGetDebtsScenario;
+    public testGetInvestmentsScenario;
 
     private currentSnapshotId: number;
 
@@ -39,6 +41,7 @@ export class ServicingScenarioRunner {
             this,
         );
         this.testGetDebtsScenario = GetDebtsRunner.testScenario.bind(this);
+        this.testGetInvestmentsScenario = GetInvestmentsRunner.testScenario.bind(this);
     }
 
     public async saveSnapshotAsync() {

--- a/__test__/integration/servicing_api/servicing_scenario_runner.ts
+++ b/__test__/integration/servicing_api/servicing_scenario_runner.ts
@@ -4,31 +4,21 @@ import * as Web3 from "web3";
 // utils
 import { Web3Utils } from "utils/web3_utils";
 
-import { OrderAPI, ServicingAPI, SignerAPI, ContractsAPI, AdaptersAPI } from "src/apis";
-import { DebtOrder } from "src/types";
-import {
-    DebtOrderWrapper,
-    DummyTokenContract,
-    RepaymentRouterContract,
-    TokenTransferProxyContract,
-} from "src/wrappers";
-import { DebtKernelContract } from "src/wrappers/contract_wrappers/debt_kernel_wrapper";
-
+// scenario runners
 import { MakeRepaymentRunner } from "./runners/make_repayment";
 import { GetValueRepaidRunner } from "./runners/get_value_repaid";
 import { GetExpectedValueRepaidRunner } from "./runners/get_expected_value_repaid";
 import { GetRepaymentScheduleRunner } from "./runners/get_repayment_schedule";
+import { GetDebtsRunner } from "./runners/get_debts";
 
 export class ServicingScenarioRunner {
     public web3Utils: Web3Utils;
-    public debtKernel: DebtKernelContract;
-    public repaymentRouter: RepaymentRouterContract;
-    public tokenTransferProxy: TokenTransferProxyContract;
-    public principalToken: DummyTokenContract;
+
     public testMakeRepaymentScenario;
     public testGetValueRepaidScenario;
     public testGetExpectedValueRepaidScenario;
     public testGetRepaymentScheduleScenario;
+    public testGetDebtsScenario;
 
     private currentSnapshotId: number;
 
@@ -48,6 +38,7 @@ export class ServicingScenarioRunner {
         this.testGetRepaymentScheduleScenario = GetRepaymentScheduleRunner.testGetRepaymentScheduleScenario.bind(
             this,
         );
+        this.testGetDebtsScenario = GetDebtsRunner.testScenario.bind(this);
     }
 
     public async saveSnapshotAsync() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharmaprotocol/dharma.js",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dharmaprotocol/dharma.js",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "",
     "keywords": [],
     "main": "dist/dharma.umd.js",

--- a/src/apis/servicing_api.ts
+++ b/src/apis/servicing_api.ts
@@ -195,8 +195,28 @@ export class ServicingAPI {
         return debtRegistry.getDebtorsDebts.callAsync(account);
     }
 
+    /**
+     * Given a creditor's account, returns a list of issuance hashes
+     * corresponding to debts which the creditor has invested in.
+     *
+     * @param account The creditor's account
+     * @return        A list of issuance hashes of the creditor's investments
+     */
     public async getInvestmentsAsync(account: string): Promise<string[]> {
-        return [""];
+        this.assert.schema.address("account", account);
+
+        const debtToken = await this.contracts.loadDebtTokenAsync();
+
+        // The ERC721-compliant token id's of debt tokens we generate
+        // are simply the issuance hashes of their corresponding
+        // debt agreements.  Thus, we can retrieve a list of
+        // a users' debt agreements by retrieving a list of tokens
+        // they own.
+        const usersDebtTokens = await debtToken.getOwnerTokens.callAsync(account);
+
+        return usersDebtTokens.map(
+            (tokenId: BigNumber) => `0x${tokenId.toString(16).padStart(64, "0")}`,
+        );
     }
 
     public async getRepaymentScheduleAsync(issuanceHash: string): Promise<Array<number>> {

--- a/src/apis/servicing_api.ts
+++ b/src/apis/servicing_api.ts
@@ -180,8 +180,19 @@ export class ServicingAPI {
         return debtRegistry.get.callAsync(issuanceHash);
     }
 
+    /**
+     * Given a debtor's account, returns a list of issuance hashes
+     * corresponding to debts which the debtor has issued in the past.
+     *
+     * @param  account The debtor's account
+     * @return         A list of issuance hashes of the debtor's debts
+     */
     public async getDebtsAsync(account: string): Promise<string[]> {
-        return [""];
+        this.assert.schema.address("account", account);
+
+        const debtRegistry = await this.contracts.loadDebtRegistryAsync();
+
+        return debtRegistry.getDebtorsDebts.callAsync(account);
     }
 
     public async getInvestmentsAsync(account: string): Promise<string[]> {

--- a/src/apis/servicing_api.ts
+++ b/src/apis/servicing_api.ts
@@ -180,6 +180,14 @@ export class ServicingAPI {
         return debtRegistry.get.callAsync(issuanceHash);
     }
 
+    public async getDebtsAsync(account: string): Promise<string[]> {
+        return [""];
+    }
+
+    public async getInvestmentsAsync(account: string): Promise<string[]> {
+        return [""];
+    }
+
     public async getRepaymentScheduleAsync(issuanceHash: string): Promise<Array<number>> {
         this.assert.schema.bytes32("issuanceHash", issuanceHash);
 

--- a/src/types/debt_order.ts
+++ b/src/types/debt_order.ts
@@ -35,7 +35,7 @@ export namespace DebtOrder {
         salt: new BigNumber(0),
         debtorSignature: NULL_ECDSA_SIGNATURE,
         creditorSignature: NULL_ECDSA_SIGNATURE,
-        underWriterSignature: NULL_ECDSA_SIGNATURE,
+        underwriterSignature: NULL_ECDSA_SIGNATURE,
     };
 
     export interface Instance {

--- a/src/wrappers/contract_wrappers/debt_registry_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_registry_wrapper.ts
@@ -139,6 +139,16 @@ export class DebtRegistryContract extends BaseContract {
             return result;
         },
     };
+    public getDebtorsDebts = {
+        async callAsync(debtor: string, defaultBlock?: Web3.BlockParam): Promise<string[]> {
+            const self = this as DebtRegistryContract;
+            const result = await promisify<[string, string]>(
+                self.web3ContractInstance.getDebtorsDebts.call,
+                self.web3ContractInstance,
+            )(debtor);
+            return result;
+        },
+    };
     public getTerms = {
         async callAsync(
             issuanceHash: string,


### PR DESCRIPTION
This PR introduces the following changes:

- Add a `getDebtsAsync` endpoint to the `dharma.servicing` API
- Add a `getInvestmentsAsync` endpoint to the `dharma.servicing` API
- Added integration test suites for both of the above.