### PR TITLE
Patch test suite broken by #36

### DIFF
--- a/__test__/integration/order_api/order_api.spec.ts
+++ b/__test__/integration/order_api/order_api.spec.ts
@@ -21,7 +21,6 @@ import {
     RepaymentRouterContract,
     SimpleInterestTermsContractContract,
     TokenTransferProxyContract,
-    TermsContractRegistryContract,
 } from "src/wrappers";
 
 import { ACCOUNTS } from "../../accounts";
@@ -42,15 +41,8 @@ const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 describe("Order API (Integration Tests)", () => {
     beforeAll(async () => {
         const dummyTokenRegistry = await TokenRegistryContract.deployed(web3, TX_DEFAULTS);
-        const termsContractRegistry = await TermsContractRegistryContract.deployed(
-            web3,
-            TX_DEFAULTS,
-        );
         const principalTokenAddress = await dummyTokenRegistry.getTokenAddressBySymbol.callAsync(
             "REP",
-        );
-        const termsContractAddress = await termsContractRegistry.getSimpleInterestTermsContractAddress.callAsync(
-            principalTokenAddress,
         );
 
         scenarioRunner.web3Utils = new Web3Utils(web3);
@@ -66,8 +58,7 @@ describe("Order API (Integration Tests)", () => {
             web3,
             TX_DEFAULTS,
         );
-        scenarioRunner.termsContract = await SimpleInterestTermsContractContract.at(
-            termsContractAddress,
+        scenarioRunner.termsContract = await SimpleInterestTermsContractContract.deployed(
             web3,
             TX_DEFAULTS,
         );

--- a/__test__/integration/order_api/scenarios/index.ts
+++ b/__test__/integration/order_api/scenarios/index.ts
@@ -25,7 +25,7 @@ export interface FillScenario {
         repaymentRouter: RepaymentRouterContract,
         principalToken: DummyTokenContract,
         termsContract: SimpleInterestTermsContractContract,
-    ) => DebtOrder;
+    ) => DebtOrder.Instance;
     filler: string;
     signatories: {
         debtor: boolean;
@@ -46,7 +46,7 @@ export interface OrderCancellationScenario {
         debtKernel: DebtKernelContract,
         repaymentRouter: RepaymentRouterContract,
         principalToken: DummyTokenContract,
-    ) => DebtOrder;
+    ) => DebtOrder.Instance;
     canceller: string;
     successfullyCancels: boolean;
     orderAlreadyCancelled: boolean;

--- a/__test__/integration/servicing_api/runners/get_debts.ts
+++ b/__test__/integration/servicing_api/runners/get_debts.ts
@@ -61,11 +61,11 @@ export class GetDebtsRunner {
                         debtor: scenario.debtor,
                         creditor: CREDITOR,
                         principalAmount: Units.ether(1),
-                        principalToken: principalToken.address,
+                        principalTokenSymbol: "REP",
                         interestRate: new BigNumber(0.1),
                         amortizationUnit: "months",
                         termLength: new BigNumber(2),
-                        salt: new BigNumber(Math.trunc(Math.random() * 10000)),
+                        salt: new BigNumber(i),
                     });
 
                     debtOrder.debtorSignature = await signerApi.asDebtor(debtOrder);
@@ -73,6 +73,11 @@ export class GetDebtsRunner {
                     const issuanceHash = await orderApi.getIssuanceHash(debtOrder);
                     issuanceHashes.push(issuanceHash);
 
+                    // NOTE: We fill debt orders in the `beforeEach` block to ensure
+                    // that the blockchain is snapshotted *before* order filling
+                    // in the parent scope's `beforeEach` block.  For more information,
+                    // read about Jest's order of execution in scoped tests:
+                    // https://facebook.github.io/jest/docs/en/setup-teardown.html#scoping
                     await orderApi.fillAsync(debtOrder, { from: CREDITOR });
                 }
             });

--- a/__test__/integration/servicing_api/runners/get_investments.ts
+++ b/__test__/integration/servicing_api/runners/get_investments.ts
@@ -65,11 +65,11 @@ export class GetInvestmentsRunner {
                         debtor: DEBTOR,
                         creditor: scenario.creditor,
                         principalAmount: Units.ether(1),
-                        principalToken: principalToken.address,
+                        principalTokenSymbol: "REP",
                         interestRate: new BigNumber(0.1),
                         amortizationUnit: "months",
                         termLength: new BigNumber(2),
-                        salt: new BigNumber(Math.trunc(Math.random() * 10000)),
+                        salt: new BigNumber(i),
                     });
 
                     debtOrder.debtorSignature = await signerApi.asDebtor(debtOrder);
@@ -77,6 +77,11 @@ export class GetInvestmentsRunner {
                     const issuanceHash = await orderApi.getIssuanceHash(debtOrder);
                     issuanceHashes.push(issuanceHash);
 
+                    // NOTE: We fill debt orders in the `beforeEach` block to ensure
+                    // that the blockchain is snapshotted *before* order filling
+                    // in the parent scope's `beforeEach` block.  For more information,
+                    // read about Jest's order of execution in scoped tests:
+                    // https://facebook.github.io/jest/docs/en/setup-teardown.html#scoping
                     await orderApi.fillAsync(debtOrder, { from: scenario.creditor });
                 }
             });

--- a/__test__/integration/servicing_api/servicing_api.spec.ts
+++ b/__test__/integration/servicing_api/servicing_api.spec.ts
@@ -58,8 +58,4 @@ describe("Debt Servicing API (Integration Tests)", () => {
     describe("#getInvestmentsAsync()", () => {
         GET_INVESTMENTS.forEach(scenarioRunner.testGetInvestmentsScenario);
     });
-
-    // TODO: Add tests for malformed TCP
-    // TODO: Add tests for different types of terms contracts
-    // TODO: Add tests for different variations of loan terms
 });

--- a/__test__/unit/adapters/simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/simple_interest_loan_adapter.spec.ts
@@ -6,6 +6,7 @@ import * as moment from "moment";
 import { BigNumber } from "utils/bignumber";
 import { ACCOUNTS } from "../../accounts";
 import * as Units from "utils/units";
+import { Web3Utils } from "utils/web3_utils";
 
 // wrappers
 import {
@@ -23,7 +24,6 @@ import {
     SimpleInterestLoanAdapter,
     SimpleInterestLoanOrder,
     SimpleInterestLoanTerms,
-    SimpleInterestTermsContractParameters,
     SimpleInterestAdapterErrors,
     AmortizationUnit,
 } from "src/adapters/simple_interest_loan_adapter";
@@ -32,6 +32,7 @@ import { ContractsAPI, ContractsError } from "src/apis/contracts_api";
 
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
+const web3Utils = new Web3Utils(web3);
 const contracts = new ContractsAPI(web3);
 const simpleInterestLoanAdapter = new SimpleInterestLoanAdapter(web3, contracts);
 const simpleInterestLoanTerms = new SimpleInterestLoanTerms(web3, contracts);
@@ -49,6 +50,16 @@ jest.unmock("@dharmaprotocol/contracts");
 jest.unmock("fs-extra");
 
 describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
+    let snapshotId: number;
+
+    beforeEach(async () => {
+        snapshotId = await web3Utils.saveTestSnapshot();
+    });
+
+    afterEach(async () => {
+        await web3Utils.revertToSnapshot(snapshotId);
+    });
+
     const defaultLoanParams = {
         principalTokenIndex: new BigNumber(0), // REP's index in the Token Registry is 0
         totalExpectedRepayment: new BigNumber(3.456 * 10 ** 18),
@@ -662,7 +673,6 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
 
         describe("debt order is valid and well-formed", () => {
             let principalTokenAddress;
-            let principalTokenSymbol;
             let termsContract;
 
             beforeAll(() => {

--- a/__test__/unit/adapters/simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/simple_interest_loan_adapter.spec.ts
@@ -10,9 +10,9 @@ import * as Units from "utils/units";
 // wrappers
 import {
     DebtKernelContract,
+    ERC20Contract,
     RepaymentRouterContract,
-    TokenRegistryContract,
-    TermsContractRegistryContract,
+    SimpleInterestTermsContractContract,
 } from "src/wrappers";
 
 // types
@@ -21,7 +21,9 @@ import { DebtOrder } from "src/types";
 // adapters
 import {
     SimpleInterestLoanAdapter,
+    SimpleInterestLoanOrder,
     SimpleInterestLoanTerms,
+    SimpleInterestTermsContractParameters,
     SimpleInterestAdapterErrors,
     AmortizationUnit,
 } from "src/adapters/simple_interest_loan_adapter";
@@ -47,98 +49,92 @@ jest.unmock("@dharmaprotocol/contracts");
 jest.unmock("fs-extra");
 
 describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
-    describe("#packParameters", () => {
-        describe("...with total expected repayment > 2^128 - 1", () => {
-            const totalExpectedRepayment = new BigNumber(3.5 * 10 ** 38);
-            const amortizationUnit = SimpleInterestLoanAdapter.Installments.DAILY;
-            const termLength = new BigNumber(7);
+    const defaultLoanParams = {
+        principalTokenIndex: new BigNumber(0), // REP's index in the Token Registry is 0
+        totalExpectedRepayment: new BigNumber(3.456 * 10 ** 18),
+        amortizationUnit: SimpleInterestLoanAdapter.Installments.DAILY,
+        termLength: new BigNumber(7),
+    };
 
+    describe("#packParameters", () => {
+        describe("...with invalid principal token index", () => {
+            // 300 is an invalid principal token index, given that we cannot encode
+            // values greater than 255 in the terms contract parameters
+            const invalidPrincipalTokenIndex = new BigNumber(300);
+
+            test("should throw INVALID_TOKEN_INDEX error", () => {
+                expect(() => {
+                    simpleInterestLoanTerms.packParameters({
+                        ...defaultLoanParams,
+                        principalTokenIndex: invalidPrincipalTokenIndex,
+                    });
+                }).toThrow(
+                    SimpleInterestAdapterErrors.INVALID_TOKEN_INDEX(invalidPrincipalTokenIndex),
+                );
+            });
+        });
+
+        describe("...with total expected repayment > 2^128 - 1", () => {
             test("should throw INVALID_EXPECTED_REPAYMENT_VALUE error", () => {
                 expect(() => {
                     simpleInterestLoanTerms.packParameters({
-                        totalExpectedRepayment,
-                        amortizationUnit,
-                        termLength,
+                        ...defaultLoanParams,
+                        totalExpectedRepayment: new BigNumber(3.5 * 10 ** 38),
                     });
                 }).toThrow(SimpleInterestAdapterErrors.INVALID_EXPECTED_REPAYMENT_VALUE());
             });
         });
 
         describe("...with total expected repayment < 0", () => {
-            const totalExpectedRepayment = new BigNumber(-1);
-            const amortizationUnit = SimpleInterestLoanAdapter.Installments.DAILY;
-            const termLength = new BigNumber(7);
-
             test("should throw INVALID_EXPECTED_REPAYMENT_VALUE error", () => {
                 expect(() => {
                     simpleInterestLoanTerms.packParameters({
-                        totalExpectedRepayment,
-                        amortizationUnit,
-                        termLength,
+                        ...defaultLoanParams,
+                        totalExpectedRepayment: new BigNumber(-1),
                     });
                 }).toThrowError(SimpleInterestAdapterErrors.INVALID_EXPECTED_REPAYMENT_VALUE());
             });
         });
 
         describe("...with non-existent amortization unit", () => {
-            const totalExpectedRepayment = new BigNumber(100);
-            const amortizationUnit = "every decade" as AmortizationUnit;
-            const termLength = new BigNumber(7);
-
             test("should throw INVALID_AMORTIZATION_UNIT_TYPE error", () => {
                 expect(() => {
                     simpleInterestLoanTerms.packParameters({
-                        totalExpectedRepayment,
-                        amortizationUnit,
-                        termLength,
+                        ...defaultLoanParams,
+                        amortizationUnit: "every decade" as AmortizationUnit,
                     });
                 }).toThrowError(SimpleInterestAdapterErrors.INVALID_AMORTIZATION_UNIT_TYPE());
             });
         });
 
         describe("...with term length > 2^120 - 1", () => {
-            const totalExpectedRepayment = new BigNumber(100);
-            const amortizationUnit = SimpleInterestLoanAdapter.Installments.DAILY;
-            const termLength = new BigNumber(3.5 * 10 ** 38);
-
             test("should throw INVALID_TERM_LENGTH error", () => {
                 expect(() => {
                     simpleInterestLoanTerms.packParameters({
-                        totalExpectedRepayment,
-                        amortizationUnit,
-                        termLength,
+                        ...defaultLoanParams,
+                        termLength: new BigNumber(3.5 * 10 ** 38),
                     });
                 }).toThrowError(SimpleInterestAdapterErrors.INVALID_TERM_LENGTH());
             });
         });
 
         describe("...with term length < 0", () => {
-            const totalExpectedRepayment = new BigNumber(100);
-            const amortizationUnit = SimpleInterestLoanAdapter.Installments.DAILY;
-            const termLength = new BigNumber(-1);
-
             test("should throw INVALID_TERM_LENGTH error", () => {
                 expect(() => {
                     simpleInterestLoanTerms.packParameters({
-                        totalExpectedRepayment,
-                        amortizationUnit,
-                        termLength,
+                        ...defaultLoanParams,
+                        termLength: new BigNumber(-1),
                     });
                 }).toThrowError(SimpleInterestAdapterErrors.INVALID_TERM_LENGTH());
             });
         });
 
         describe("...with term length not specified in whole numbers", () => {
-            const totalExpectedRepayment = new BigNumber(100);
-            const amortizationUnit = SimpleInterestLoanAdapter.Installments.DAILY;
-            const termLength = new BigNumber(1.3);
-
             test("should throw INVALID_TERM_LENGTH error", () => {
                 expect(() => {
                     simpleInterestLoanTerms.packParameters({
-                        totalExpectedRepayment,
-                        amortizationUnit,
-                        termLength,
+                        ...defaultLoanParams,
+                        termLength: new BigNumber(1.3),
                     });
                 }).toThrowError(/Expected termLength to conform to schema \/WholeNumber/);
             });
@@ -146,22 +142,15 @@ describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
 
         describe("...with valid expected repayment, amortization, and term length", () => {
             describe("Scenario #1", () => {
-                const totalExpectedRepayment = new BigNumber(3.456 * 10 ** 18);
-                const amortizationUnit = SimpleInterestLoanAdapter.Installments.DAILY;
-                const termLength = new BigNumber(7);
-
                 test("should return correctly packed parameters", () => {
-                    expect(
-                        simpleInterestLoanTerms.packParameters({
-                            totalExpectedRepayment,
-                            amortizationUnit,
-                            termLength,
-                        }),
-                    ).toEqual("0x00000000000000002ff62db077c0000001000000000000000000000000000007");
+                    expect(simpleInterestLoanTerms.packParameters(defaultLoanParams)).toEqual(
+                        "0x00000000000000002ff62db077c0000010007000000000000000000000000000",
+                    );
                 });
             });
 
             describe("Scenario #2", () => {
+                const principalTokenIndex = new BigNumber(1);
                 const totalExpectedRepayment = new BigNumber(723489020 * 10 ** 18);
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.YEARLY;
                 const termLength = new BigNumber(4);
@@ -169,15 +158,17 @@ describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
                 test("should return correctly packed parameters", () => {
                     expect(
                         simpleInterestLoanTerms.packParameters({
+                            principalTokenIndex,
                             totalExpectedRepayment,
                             amortizationUnit,
                             termLength,
                         }),
-                    ).toEqual("0x00000000025674c25cd7f81d0670000004000000000000000000000000000004");
+                    ).toEqual("0x01000000025674c25cd7f81d0670000040004000000000000000000000000000");
                 });
             });
 
             describe("Scenario #3", () => {
+                const principalTokenIndex = new BigNumber(2);
                 const totalExpectedRepayment = new BigNumber(0.0000023232312 * 10 ** 18);
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.MONTHLY;
                 const termLength = new BigNumber(12);
@@ -185,11 +176,12 @@ describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
                 test("should return correctly packed parameters", () => {
                     expect(
                         simpleInterestLoanTerms.packParameters({
+                            principalTokenIndex,
                             totalExpectedRepayment,
                             amortizationUnit,
                             termLength,
                         }),
-                    ).toEqual("0x00000000000000000000021ceb5ed3000300000000000000000000000000000c");
+                    ).toEqual("0x02000000000000000000021ceb5ed3003000c000000000000000000000000000");
                 });
             });
         });
@@ -198,7 +190,7 @@ describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
     describe("#unpackParameters", () => {
         describe("...with amortization unit > 4", () => {
             const termsContractParameters =
-                "0x00000000025674c25cd7f81d0670000005000000000000000000000000000004";
+                "0x0000000025674c25cd7f81d06700000050004000000000000000000000000000";
 
             test("should throw INVALID_AMORTIZATION_UNIT_TYPE error", () => {
                 expect(() => {
@@ -248,24 +240,20 @@ describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
         describe("...with termsContractParameters string", () => {
             describe("Scenario #1", () => {
                 const parameters =
-                    "0x00000000000000002ff62db077c0000001000000000000000000000000000007";
-                const unpackedParameters = {
-                    totalExpectedRepayment: new BigNumber(3.456 * 10 ** 18),
-                    amortizationUnit: SimpleInterestLoanAdapter.Installments.DAILY,
-                    termLength: new BigNumber(7),
-                };
+                    "0x00000000000000002ff62db077c0000010007000000000000000000000000000";
 
                 test("should return correctly unpacked parameters", () => {
                     expect(simpleInterestLoanTerms.unpackParameters(parameters)).toEqual(
-                        unpackedParameters,
+                        defaultLoanParams,
                     );
                 });
             });
 
             describe("Scenario #2", () => {
                 const parameters =
-                    "0x00000000025674c25cd7f81d0670000004000000000000000000000000000004";
+                    "0x01000000025674c25cd7f81d0670000040004000000000000000000000000000";
                 const unpackedParameters = {
+                    principalTokenIndex: new BigNumber(1),
                     totalExpectedRepayment: new BigNumber(723489020 * 10 ** 18),
                     amortizationUnit: SimpleInterestLoanAdapter.Installments.YEARLY,
                     termLength: new BigNumber(4),
@@ -280,8 +268,9 @@ describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
 
             describe("Scenario #3", () => {
                 const parameters =
-                    "0x00000000000000000000021ceb5ed3000300000000000000000000000000000c";
+                    "0x05000000000000000000021ceb5ed3003000c000000000000000000000000000";
                 const unpackedParameters = {
+                    principalTokenIndex: new BigNumber(5),
                     totalExpectedRepayment: new BigNumber(0.0000023232312 * 10 ** 18),
                     amortizationUnit: SimpleInterestLoanAdapter.Installments.MONTHLY,
                     termLength: new BigNumber(12),
@@ -300,45 +289,46 @@ describe("Simple Interest Terms Contract Interface (Unit Tests)", () => {
 describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
     let debtKernelAddress: string;
     let repaymentRouterAddress: string;
-    let principalTokenAddress: string;
+
+    let defaultLoanOrder: SimpleInterestLoanOrder;
 
     beforeAll(async () => {
         const debtKernel = await DebtKernelContract.deployed(web3, TX_DEFAULTS);
         const repaymentRouter = await RepaymentRouterContract.deployed(web3, TX_DEFAULTS);
-        const dummyTokenRegistry = await TokenRegistryContract.deployed(web3, TX_DEFAULTS);
 
         debtKernelAddress = debtKernel.address;
         repaymentRouterAddress = repaymentRouter.address;
-        principalTokenAddress = await dummyTokenRegistry.getTokenAddressBySymbol.callAsync("REP");
+
+        defaultLoanOrder = {
+            principalAmount: Units.ether(1),
+            principalTokenSymbol: "REP",
+            interestRate: new BigNumber(0.14),
+            amortizationUnit: SimpleInterestLoanAdapter.Installments.WEEKLY,
+            termLength: new BigNumber(2),
+        };
     });
 
     describe("#toDebtOrder", () => {
         describe("simple interest loan's required parameter is missing or malformed", () => {
-            describe("principalToken missing", () => {
+            describe("principalTokenSymbol missing", () => {
                 it("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
-                            principalAmount: Units.ether(1),
-                            principalToken: undefined,
-                            interestRate: new BigNumber(0.14),
-                            amortizationUnit: SimpleInterestLoanAdapter.Installments.WEEKS,
-                            termLength: new BigNumber(2),
+                            ...defaultLoanOrder,
+                            principalTokenSymbol: undefined,
                         }),
-                    ).rejects.toThrow('instance requires property "principalToken"');
+                    ).rejects.toThrow('instance requires property "principalTokenSymbol"');
                 });
             });
 
-            describe("principalToken malformed", () => {
-                it("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+            describe("principalTokenSymbol is not tracked by Token Registry", () => {
+                it("should throw PRINCIPAL_TOKEN_NOT_SUPPORTED", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
-                            principalAmount: Units.ether(1),
-                            principalToken: principalTokenAddress.substr(5),
-                            interestRate: new BigNumber(0.14),
-                            amortizationUnit: SimpleInterestLoanAdapter.Installments.WEEKS,
-                            termLength: new BigNumber(2),
+                            ...defaultLoanOrder,
+                            principalTokenSymbol: "EOS", // EOS is not tracked in our test env's registry
                         }),
-                    ).rejects.toThrow("instance.principalToken does not match pattern");
+                    ).rejects.toThrow(ContractsError.CANNOT_FIND_TOKEN_WITH_SYMBOL("EOS"));
                 });
             });
 
@@ -346,11 +336,8 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 it("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
+                            ...defaultLoanOrder,
                             principalAmount: undefined,
-                            principalToken: principalTokenAddress,
-                            interestRate: new BigNumber(0.14),
-                            amortizationUnit: SimpleInterestLoanAdapter.Installments.WEEKS,
-                            termLength: new BigNumber(2),
                         }),
                     ).rejects.toThrow('instance requires property "principalAmount"');
                 });
@@ -360,11 +347,8 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 it("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
-                            principalAmount: Units.ether(1),
-                            principalToken: principalTokenAddress,
+                            ...defaultLoanOrder,
                             interestRate: undefined,
-                            amortizationUnit: SimpleInterestLoanAdapter.Installments.WEEKS,
-                            termLength: new BigNumber(2),
                         }),
                     ).rejects.toThrow('instance requires property "interestRate"');
                 });
@@ -374,11 +358,8 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 it("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
-                            principalAmount: Units.ether(1),
-                            principalToken: principalTokenAddress,
-                            interestRate: new BigNumber(0.14),
+                            ...defaultLoanOrder,
                             amortizationUnit: undefined,
-                            termLength: new BigNumber(2),
                         }),
                     ).rejects.toThrow('instance requires property "amortizationUnit"');
                 });
@@ -388,11 +369,8 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 it("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
-                            principalAmount: Units.ether(1),
-                            principalToken: principalTokenAddress,
-                            interestRate: new BigNumber(0.14),
+                            ...defaultLoanOrder,
                             amortizationUnit: "decades" as AmortizationUnit,
-                            termLength: new BigNumber(2),
                         }),
                     ).rejects.toThrow("instance.amortizationUnit does not match pattern");
                 });
@@ -402,10 +380,7 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 it("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
-                            principalAmount: Units.ether(1),
-                            principalToken: principalTokenAddress,
-                            interestRate: new BigNumber(0.14),
-                            amortizationUnit: SimpleInterestLoanAdapter.Installments.WEEKLY,
+                            ...defaultLoanOrder,
                             termLength: undefined,
                         }),
                     ).rejects.toThrow('instance requires property "termLength"');
@@ -413,34 +388,13 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
             });
         });
 
-        describe("simple interest terms contract not deployed for given token address", () => {
-            const fakePrincipalToken = ACCOUNTS[0].address;
-
-            it("should throw PRINCIPAL_TOKEN_NOT_SUPPORTED", async () => {
-                await expect(
-                    simpleInterestLoanAdapter.toDebtOrder({
-                        principalAmount: Units.ether(1),
-                        principalToken: fakePrincipalToken,
-                        interestRate: new BigNumber(0.14),
-                        amortizationUnit: SimpleInterestLoanAdapter.Installments.DAILY,
-                        termLength: new BigNumber(2),
-                    }),
-                ).rejects.toThrow(
-                    ContractsError.SIMPLE_INTEREST_TERMS_CONTRACT_NOT_SUPPORTED(fakePrincipalToken),
-                );
-            });
-        });
-
         describe("simple interest loan's required parameters are present and well formed ", () => {
-            let simpleInterestTermsContractAddress: string;
+            let simpleInterestTermsContract: SimpleInterestTermsContractContract;
+            let principalToken: ERC20Contract;
 
             beforeAll(async () => {
-                const termsContractRegistry = await TermsContractRegistryContract.deployed(
-                    web3,
+                simpleInterestTermsContract = await contracts.loadSimpleInterestTermsContract(
                     TX_DEFAULTS,
-                );
-                simpleInterestTermsContractAddress = await termsContractRegistry.getSimpleInterestTermsContractAddress.callAsync(
-                    principalTokenAddress,
                 );
             });
 
@@ -450,11 +404,15 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.WEEKLY;
                 const termLength = new BigNumber(2);
 
+                beforeAll(async () => {
+                    principalToken = await contracts.loadTokenBySymbolAsync("REP", TX_DEFAULTS);
+                });
+
                 it("should return debt order with correctly packed values", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
                             principalAmount,
-                            principalToken: principalTokenAddress,
+                            principalTokenSymbol: "REP",
                             interestRate,
                             amortizationUnit,
                             termLength,
@@ -464,10 +422,10 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                         kernelVersion: debtKernelAddress,
                         issuanceVersion: repaymentRouterAddress,
                         principalAmount,
-                        principalToken: principalTokenAddress,
-                        termsContract: simpleInterestTermsContractAddress,
+                        principalToken: principalToken.address,
+                        termsContract: simpleInterestTermsContract.address,
                         termsContractParameters:
-                            "0x00000000000000000fd217f5c3f2000002000000000000000000000000000002",
+                            "0x00000000000000000fd217f5c3f2000020002000000000000000000000000000",
                     });
                 });
             });
@@ -478,11 +436,15 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.YEARLY;
                 const termLength = new BigNumber(1);
 
+                beforeAll(async () => {
+                    principalToken = await contracts.loadTokenBySymbolAsync("MKR", TX_DEFAULTS);
+                });
+
                 it("should return debt order with correctly packed values", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
                             principalAmount,
-                            principalToken: principalTokenAddress,
+                            principalTokenSymbol: "MKR",
                             interestRate,
                             amortizationUnit,
                             termLength,
@@ -492,10 +454,10 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                         kernelVersion: debtKernelAddress,
                         issuanceVersion: repaymentRouterAddress,
                         principalAmount,
-                        principalToken: principalTokenAddress,
-                        termsContract: simpleInterestTermsContractAddress,
+                        principalToken: principalToken.address,
+                        termsContract: simpleInterestTermsContract.address,
                         termsContractParameters:
-                            "0x00000000000000000b26400b1c8c800004000000000000000000000000000001",
+                            "0x01000000000000000b26400b1c8c800040001000000000000000000000000000",
                     });
                 });
             });
@@ -506,11 +468,15 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.MONTHLY;
                 const termLength = new BigNumber(12);
 
+                beforeAll(async () => {
+                    principalToken = await contracts.loadTokenBySymbolAsync("ZRX", TX_DEFAULTS);
+                });
+
                 it("should return debt order with correctly packed values", async () => {
                     await expect(
                         simpleInterestLoanAdapter.toDebtOrder({
                             principalAmount,
-                            principalToken: principalTokenAddress,
+                            principalTokenSymbol: "ZRX",
                             interestRate,
                             amortizationUnit,
                             termLength,
@@ -520,10 +486,10 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                         kernelVersion: debtKernelAddress,
                         issuanceVersion: repaymentRouterAddress,
                         principalAmount,
-                        principalToken: principalTokenAddress,
-                        termsContract: simpleInterestTermsContractAddress,
+                        principalToken: principalToken.address,
+                        termsContract: simpleInterestTermsContract.address,
                         termsContractParameters:
-                            "0x0000000000002a5b1b1e089f00d000000300000000000000000000000000000c",
+                            "0x0200000000002a5b1b1e089f00d000003000c000000000000000000000000000",
                     });
                 });
             });
@@ -535,23 +501,20 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
         let termsContract;
 
         beforeAll(async () => {
-            const termsContractRegistry = await TermsContractRegistryContract.deployed(
-                web3,
-                TX_DEFAULTS,
-            );
-            simpleInterestTermsContractAddress = await termsContractRegistry.getSimpleInterestTermsContractAddress.callAsync(
-                principalTokenAddress,
-            );
+            const simpleInterestTermsContract = await contracts.loadSimpleInterestTermsContract();
+            simpleInterestTermsContractAddress = simpleInterestTermsContract.address;
 
             termsContract = simpleInterestTermsContractAddress;
         });
 
         describe("when the schedule is across 2 weeks", () => {
             test("it returns a list of 2 unix timestamps 1 week apart", async () => {
+                const principalTokenIndex = new BigNumber(0);
                 const totalExpectedRepayment = new BigNumber(1);
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.WEEKLY;
                 const termLength = new BigNumber(2);
                 const contractTermsParameters = simpleInterestLoanTerms.packParameters({
+                    principalTokenIndex,
                     totalExpectedRepayment,
                     amortizationUnit,
                     termLength,
@@ -588,17 +551,15 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
         });
     });
 
-    describe("#fromDebtToken()", () => {
+    describe("#fromDebtOrder()", () => {
         let simpleInterestTermsContractAddress: string;
+        let principalTokenAddress: string;
 
         beforeAll(async () => {
-            const termsContractRegistry = await TermsContractRegistryContract.deployed(
-                web3,
-                TX_DEFAULTS,
-            );
-            simpleInterestTermsContractAddress = await termsContractRegistry.getSimpleInterestTermsContractAddress.callAsync(
-                principalTokenAddress,
-            );
+            const simpleInterestTermsContract = await contracts.loadSimpleInterestTermsContract();
+            simpleInterestTermsContractAddress = simpleInterestTermsContract.address;
+
+            principalTokenAddress = await contracts.getTokenAddressBySymbolAsync("REP");
         });
 
         describe("argument does not conform to the DebtOrderWithTermsSpecified schema", () => {
@@ -664,19 +625,22 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
         });
 
         describe("terms contract does not match principal token's associated SimpleInterestTermsContract", () => {
-            it("should throw INVALID_TERMS_CONTRACT", async () => {
+            it("should throw MISMATCHED_TOKEN_SYMBOL", async () => {
                 await expect(
                     simpleInterestLoanAdapter.fromDebtOrder({
                         principalToken: principalTokenAddress,
                         principalAmount: Units.ether(1),
                         termsContract: ACCOUNTS[0].address,
+                        // We specify a token index of 1 in this parameter string,
+                        // which is not the index of the specified principal token
+                        // in the debt order (i.e. REP);.
                         termsContractParameters:
-                            "0x0000000000002a5b1b1e089f00d000000300000000000000000000000000000c",
+                            "0x0100000000002a5b1b1e089f00d000000300000000000000000000000000000c",
                     }),
                 ).rejects.toThrow(
-                    SimpleInterestAdapterErrors.INVALID_TERMS_CONTRACT(
+                    SimpleInterestAdapterErrors.MISMATCHED_TOKEN_SYMBOL(
                         principalTokenAddress,
-                        ACCOUNTS[0].address,
+                        "MKR",
                     ),
                 );
             });
@@ -690,18 +654,18 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                         principalAmount: Units.ether(1),
                         termsContract: simpleInterestTermsContractAddress,
                         termsContractParameters:
-                            "0x0000000000002a5b1b1e089f00d000000600000000000000000000000000000c",
+                            "0x0000000000002a5b1b1e089f00d000006000c000000000000000000000000000",
                     }),
                 ).rejects.toThrow(SimpleInterestAdapterErrors.INVALID_AMORTIZATION_UNIT_TYPE());
             });
         });
 
         describe("debt order is valid and well-formed", () => {
-            let principalToken;
+            let principalTokenAddress;
+            let principalTokenSymbol;
             let termsContract;
 
             beforeAll(() => {
-                principalToken = principalTokenAddress;
                 termsContract = simpleInterestTermsContractAddress;
             });
 
@@ -711,19 +675,25 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.WEEKLY;
                 const termLength = new BigNumber(2);
                 const termsContractParameters =
-                    "0x00000000000000000fd217f5c3f2000002000000000000000000000000000002";
+                    "0x00000000000000000fd217f5c3f2000020002000000000000000000000000000";
+
+                beforeAll(async () => {
+                    const principalToken = await contracts.loadTokenBySymbolAsync("REP");
+                    principalTokenAddress = principalToken.address;
+                });
 
                 it("should return SimpleInterestLoanOrder with correctly unpacked values", async () => {
                     await expect(
                         simpleInterestLoanAdapter.fromDebtOrder({
                             principalAmount,
-                            principalToken,
+                            principalToken: principalTokenAddress,
                             termsContract,
                             termsContractParameters,
                         }),
                     ).resolves.toEqual({
                         principalAmount,
-                        principalToken,
+                        principalToken: principalTokenAddress,
+                        principalTokenSymbol: "REP",
                         termsContract,
                         termsContractParameters,
                         interestRate,
@@ -739,19 +709,25 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.YEARLY;
                 const termLength = new BigNumber(1);
                 const termsContractParameters =
-                    "0x00000000000000000b26400b1c8c800004000000000000000000000000000001";
+                    "0x01000000000000000b26400b1c8c800040001000000000000000000000000000";
+
+                beforeAll(async () => {
+                    const principalToken = await contracts.loadTokenBySymbolAsync("MKR");
+                    principalTokenAddress = principalToken.address;
+                });
 
                 it("should return SimpleInterestLoanOrder with correctly unpacked values", async () => {
                     await expect(
                         simpleInterestLoanAdapter.fromDebtOrder({
                             principalAmount,
-                            principalToken,
+                            principalToken: principalTokenAddress,
                             termsContract,
                             termsContractParameters,
                         }),
                     ).resolves.toEqual({
                         principalAmount,
-                        principalToken,
+                        principalToken: principalTokenAddress,
+                        principalTokenSymbol: "MKR",
                         termsContract,
                         termsContractParameters,
                         interestRate,
@@ -767,19 +743,25 @@ describe("Simple Interest Loan Adapter (Unit Tests)", async () => {
                 const amortizationUnit = SimpleInterestLoanAdapter.Installments.MONTHLY;
                 const termLength = new BigNumber(12);
                 const termsContractParameters =
-                    "0x0000000000002a5b1b1e089f00d000000300000000000000000000000000000c";
+                    "0x0200000000002a5b1b1e089f00d000003000c000000000000000000000000000";
+
+                beforeAll(async () => {
+                    const principalToken = await contracts.loadTokenBySymbolAsync("ZRX");
+                    principalTokenAddress = principalToken.address;
+                });
 
                 it("should return SimpleInterestLoanOrder with correctly unpacked values", async () => {
                     await expect(
                         simpleInterestLoanAdapter.fromDebtOrder({
                             principalAmount,
-                            principalToken,
+                            principalToken: principalTokenAddress,
                             termsContract,
                             termsContractParameters,
                         }),
                     ).resolves.toEqual({
                         principalAmount,
-                        principalToken,
+                        principalToken: principalTokenAddress,
+                        principalTokenSymbol: "ZRX",
                         termsContract,
                         termsContractParameters,
                         interestRate,

--- a/__test__/unit/blockchain_api/scenarios/index.ts
+++ b/__test__/unit/blockchain_api/scenarios/index.ts
@@ -10,6 +10,7 @@ import { INVALID_REPAYMENT_SCENARIOS } from "./invalid_repayments";
 
 export {
     DebtKernelErrorScenario,
+    RepaymentRouterErrorScenario,
     INVALID_ORDERS,
     VALID_ORDERS,
     VALID_REPAYMENTS,


### PR DESCRIPTION
This PR introduces the following changes:

- Fixes various test suites throughout the codebase that are affected by the changes introduced in #36 
- Importantly, patches all servicing api test runners such that, now, the blockchain is always snapshotted before each test scenario is run.  This helps us prevent mysterious `Debt order has already been filled` errors.
