### PR TITLE
Add `shouldAddPersonalMessagePrefix` arg to signer API methods

### DIFF
--- a/__test__/integration/signer_api.spec.ts
+++ b/__test__/integration/signer_api.spec.ts
@@ -4,7 +4,7 @@ import { SignerAPI, SignerAPIErrors } from "src/apis/signer_api";
 import * as Units from "utils/units";
 import * as moment from "moment";
 import * as Web3 from "web3";
-import { signatureUtils } from "utils/signature_utils";
+import { SignatureUtils } from "utils/signature_utils";
 
 import { Web3Utils } from "utils/web3_utils";
 
@@ -71,9 +71,9 @@ describe("Order Signer (Unit Tests)", () => {
                 debtOrderUndefinedDebtor.debtor = undefined;
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
-                    await expect(orderSigner.asDebtor(debtOrderUndefinedDebtor)).rejects.toThrow(
-                        /requires property "debtor"/,
-                    );
+                    await expect(
+                        orderSigner.asDebtor(debtOrderUndefinedDebtor, false),
+                    ).rejects.toThrow(/requires property "debtor"/);
                 });
             });
 
@@ -82,9 +82,9 @@ describe("Order Signer (Unit Tests)", () => {
                 debtOrderMalformedDebtor.debtor = "0x12345malformed";
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
-                    await expect(orderSigner.asDebtor(debtOrderMalformedDebtor)).rejects.toThrow(
-                        /\.debtor does not match pattern/,
-                    );
+                    await expect(
+                        orderSigner.asDebtor(debtOrderMalformedDebtor, false),
+                    ).rejects.toThrow(/\.debtor does not match pattern/);
                 });
             });
 
@@ -93,9 +93,9 @@ describe("Order Signer (Unit Tests)", () => {
                 debtOrderUndefinedPrincipal.principalAmount = undefined;
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
-                    await expect(orderSigner.asDebtor(debtOrderUndefinedPrincipal)).rejects.toThrow(
-                        /requires property "principalAmount"/,
-                    );
+                    await expect(
+                        orderSigner.asDebtor(debtOrderUndefinedPrincipal, false),
+                    ).rejects.toThrow(/requires property "principalAmount"/);
                 });
             });
 
@@ -104,7 +104,9 @@ describe("Order Signer (Unit Tests)", () => {
                 debtOrderMalformedPrincipal.principalAmount = 14;
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
-                    await expect(orderSigner.asDebtor(debtOrderMalformedPrincipal)).rejects.toThrow(
+                    await expect(
+                        orderSigner.asDebtor(debtOrderMalformedPrincipal, false),
+                    ).rejects.toThrow(
                         /\.principalAmount does not conform to the "BigNumber" format/,
                     );
                 });
@@ -116,7 +118,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asDebtor(debtOrderMissingPrincipalToken),
+                        orderSigner.asDebtor(debtOrderMissingPrincipalToken, false),
                     ).rejects.toThrow(/requires property "principalToken"/);
                 });
             });
@@ -127,7 +129,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asDebtor(debtOrderMalformedPrincipalToken),
+                        orderSigner.asDebtor(debtOrderMalformedPrincipalToken, false),
                     ).rejects.toThrow(/\.principalToken does not match pattern/);
                 });
             });
@@ -138,7 +140,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asDebtor(debtOrderUndefinedTermsContract),
+                        orderSigner.asDebtor(debtOrderUndefinedTermsContract, false),
                     ).rejects.toThrow(/requires property "termsContract"/);
                 });
             });
@@ -149,7 +151,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asDebtor(debtOrderMalformedTermsContract),
+                        orderSigner.asDebtor(debtOrderMalformedTermsContract, false),
                     ).rejects.toThrow(/\.termsContract does not match pattern/);
                 });
             });
@@ -160,7 +162,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asDebtor(debtOrderUndefinedTermsContractParams),
+                        orderSigner.asDebtor(debtOrderUndefinedTermsContractParams, false),
                     ).rejects.toThrow(/requires property "termsContractParameters"/);
                 });
             });
@@ -171,7 +173,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asDebtor(debtOrderMalformedTermsContractParams),
+                        orderSigner.asDebtor(debtOrderMalformedTermsContractParams, false),
                     ).rejects.toThrow(/\.termsContractParameters does not match pattern/);
                 });
             });
@@ -182,7 +184,7 @@ describe("Order Signer (Unit Tests)", () => {
             debtOrderWithNullDebtor.debtor = NULL_ADDRESS;
 
             test("throws INVALID_SIGNING_KEY error", async () => {
-                await expect(orderSigner.asDebtor(debtOrderWithNullDebtor)).rejects.toThrow(
+                await expect(orderSigner.asDebtor(debtOrderWithNullDebtor, false)).rejects.toThrow(
                     SignerAPIErrors.INVALID_SIGNING_KEY(NULL_ADDRESS),
                 );
             });
@@ -193,17 +195,19 @@ describe("Order Signer (Unit Tests)", () => {
             debtOrderWithExternalDebtor.debtor = "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe";
 
             test("throws INVALID_SIGNING_KEY error", async () => {
-                await expect(orderSigner.asDebtor(debtOrderWithExternalDebtor)).rejects.toThrow(
+                await expect(
+                    orderSigner.asDebtor(debtOrderWithExternalDebtor, false),
+                ).rejects.toThrow(
                     SignerAPIErrors.INVALID_SIGNING_KEY(debtOrderWithExternalDebtor.debtor),
                 );
             });
         });
 
         describe("...with debtor's private key available and unlocked", () => {
-            test("returns valid signature", async () => {
-                const ecdsaSignature = await orderSigner.asDebtor(debtOrder);
+            let debtOrderHash: string;
 
-                const debtOrderHash = Web3Utils.soliditySHA3(
+            beforeAll(() => {
+                debtOrderHash = Web3Utils.soliditySHA3(
                     debtOrder.kernelVersion,
                     Web3Utils.soliditySHA3(
                         debtOrder.issuanceVersion,
@@ -223,14 +227,47 @@ describe("Order Signer (Unit Tests)", () => {
                     debtOrder.relayerFee,
                     debtOrder.expirationTimestampInSec,
                 );
+            });
 
-                expect(
-                    signatureUtils.isValidSignature(
+            describe("on signing client that expects hashed message w/ personal message prefix", () => {
+                test("returns valid signature", async () => {
+                    const ecdsaSignature = await orderSigner.asDebtor(debtOrder, true);
+
+                    // Given that our test environment (namely, Ganache) is a client that
+                    // prepends the personal message prefix on the user's behalf, the correctly
+                    // produced signature in this test environment will actually
+                    // redundantly prepend a personal message prefix to the payload
+                    // twice.  Thus, to test for correctness as best we can, we redundantly prefix
+                    // and hash the debtOrderHash -- once below, and again in the `isValidSignature`
+                    // mtheod.
+                    const prefixedDebtOrderHash = SignatureUtils.addPersonalMessagePrefix(
                         debtOrderHash,
-                        ecdsaSignature,
-                        debtOrder.debtor,
-                    ),
-                ).toBeTruthy();
+                    );
+
+                    expect(
+                        SignatureUtils.isValidSignature(
+                            prefixedDebtOrderHash,
+                            ecdsaSignature,
+                            debtOrder.debtor,
+                            true,
+                        ),
+                    ).toBeTruthy();
+                });
+            });
+
+            describe("on signing client that adds personal message prefix on user's behalf", () => {
+                test("returns valid signature", async () => {
+                    const ecdsaSignature = await orderSigner.asDebtor(debtOrder, false);
+
+                    expect(
+                        SignatureUtils.isValidSignature(
+                            debtOrderHash,
+                            ecdsaSignature,
+                            debtOrder.debtor,
+                            true,
+                        ),
+                    ).toBeTruthy();
+                });
             });
         });
     });
@@ -246,9 +283,9 @@ describe("Order Signer (Unit Tests)", () => {
                 debtOrderUndefinedDebtor.debtor = undefined;
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
-                    await expect(orderSigner.asCreditor(debtOrderUndefinedDebtor)).rejects.toThrow(
-                        /requires property "debtor"/,
-                    );
+                    await expect(
+                        orderSigner.asCreditor(debtOrderUndefinedDebtor, false),
+                    ).rejects.toThrow(/requires property "debtor"/);
                 });
             });
 
@@ -257,9 +294,9 @@ describe("Order Signer (Unit Tests)", () => {
                 debtOrderMalformedDebtor.debtor = "0x12345malformed";
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
-                    await expect(orderSigner.asCreditor(debtOrderMalformedDebtor)).rejects.toThrow(
-                        /\.debtor does not match pattern/,
-                    );
+                    await expect(
+                        orderSigner.asCreditor(debtOrderMalformedDebtor, false),
+                    ).rejects.toThrow(/\.debtor does not match pattern/);
                 });
             });
 
@@ -269,7 +306,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderUndefinedCreditor),
+                        orderSigner.asCreditor(debtOrderUndefinedCreditor, false),
                     ).rejects.toThrow(/requires property "creditor"/);
                 });
             });
@@ -280,7 +317,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderMalformedCreditor),
+                        orderSigner.asCreditor(debtOrderMalformedCreditor, false),
                     ).rejects.toThrow(/\.creditor does not match pattern/);
                 });
             });
@@ -291,7 +328,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderUndefinedPrincipal),
+                        orderSigner.asCreditor(debtOrderUndefinedPrincipal, false),
                     ).rejects.toThrow(/requires property "principalAmount"/);
                 });
             });
@@ -313,7 +350,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderMissingPrincipalToken),
+                        orderSigner.asCreditor(debtOrderMissingPrincipalToken, false),
                     ).rejects.toThrow(/requires property "principalToken"/);
                 });
             });
@@ -324,7 +361,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderMalformedPrincipalToken),
+                        orderSigner.asCreditor(debtOrderMalformedPrincipalToken, false),
                     ).rejects.toThrow(/\.principalToken does not match pattern/);
                 });
             });
@@ -335,7 +372,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderUndefinedTermsContract),
+                        orderSigner.asCreditor(debtOrderUndefinedTermsContract, false),
                     ).rejects.toThrow(/requires property "termsContract"/);
                 });
             });
@@ -346,7 +383,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderMalformedTermsContract),
+                        orderSigner.asCreditor(debtOrderMalformedTermsContract, false),
                     ).rejects.toThrow(/\.termsContract does not match pattern/);
                 });
             });
@@ -357,7 +394,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderUndefinedTermsContractParams),
+                        orderSigner.asCreditor(debtOrderUndefinedTermsContractParams, false),
                     ).rejects.toThrow(/requires property "termsContractParameters"/);
                 });
             });
@@ -368,7 +405,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asCreditor(debtOrderMalformedTermsContractParams),
+                        orderSigner.asCreditor(debtOrderMalformedTermsContractParams, false),
                     ).rejects.toThrow(/\.termsContractParameters does not match pattern/);
                 });
             });
@@ -379,9 +416,9 @@ describe("Order Signer (Unit Tests)", () => {
             debtOrderWithNullCreditor.creditor = NULL_ADDRESS;
 
             test("throws INVALID_SIGNING_KEY error", async () => {
-                await expect(orderSigner.asCreditor(debtOrderWithNullCreditor)).rejects.toThrow(
-                    SignerAPIErrors.INVALID_SIGNING_KEY(NULL_ADDRESS),
-                );
+                await expect(
+                    orderSigner.asCreditor(debtOrderWithNullCreditor, false),
+                ).rejects.toThrow(SignerAPIErrors.INVALID_SIGNING_KEY(NULL_ADDRESS));
             });
         });
 
@@ -390,17 +427,19 @@ describe("Order Signer (Unit Tests)", () => {
             debtOrderWithExternalCreditor.creditor = "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe";
 
             test("throws INVALID_SIGNING_KEY error", async () => {
-                await expect(orderSigner.asCreditor(debtOrderWithExternalCreditor)).rejects.toThrow(
+                await expect(
+                    orderSigner.asCreditor(debtOrderWithExternalCreditor, false),
+                ).rejects.toThrow(
                     SignerAPIErrors.INVALID_SIGNING_KEY(debtOrderWithExternalCreditor.creditor),
                 );
             });
         });
 
         describe("...with creditor's private key available and unlocked", () => {
-            test("returns valid signature", async () => {
-                const ecdsaSignature = await orderSigner.asCreditor(debtOrder);
+            let debtOrderHash: string;
 
-                const debtOrderHash = Web3Utils.soliditySHA3(
+            beforeAll(() => {
+                debtOrderHash = Web3Utils.soliditySHA3(
                     debtOrder.kernelVersion,
                     Web3Utils.soliditySHA3(
                         debtOrder.issuanceVersion,
@@ -420,14 +459,47 @@ describe("Order Signer (Unit Tests)", () => {
                     debtOrder.relayerFee,
                     debtOrder.expirationTimestampInSec,
                 );
+            });
 
-                expect(
-                    signatureUtils.isValidSignature(
+            describe("on signing client that expects hashed message w/ personal message prefix", () => {
+                test("returns valid signature", async () => {
+                    const ecdsaSignature = await orderSigner.asCreditor(debtOrder, true);
+
+                    // Given that our test environment (namely, Ganache) is a client that
+                    // prepends the personal message prefix on the user's behalf, the correctly
+                    // produced signature in this test environment will actually
+                    // redundantly prepend a personal message prefix to the payload
+                    // twice.  Thus, to test for correctness as best we can, we redundantly prefix
+                    // and hash the debtOrderHash -- once below, and again in the `isValidSignature`
+                    // mtheod.
+                    const prefixedDebtOrderHash = SignatureUtils.addPersonalMessagePrefix(
                         debtOrderHash,
-                        ecdsaSignature,
-                        debtOrder.creditor,
-                    ),
-                ).toBeTruthy();
+                    );
+
+                    expect(
+                        SignatureUtils.isValidSignature(
+                            prefixedDebtOrderHash,
+                            ecdsaSignature,
+                            debtOrder.creditor,
+                            true,
+                        ),
+                    ).toBeTruthy();
+                });
+            });
+
+            describe("on signing client that adds personal message prefix on user's behalf", () => {
+                test("returns valid signature", async () => {
+                    const ecdsaSignature = await orderSigner.asCreditor(debtOrder, false);
+
+                    expect(
+                        SignatureUtils.isValidSignature(
+                            debtOrderHash,
+                            ecdsaSignature,
+                            debtOrder.creditor,
+                            true,
+                        ),
+                    ).toBeTruthy();
+                });
             });
         });
     });
@@ -444,7 +516,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderUndefinedDebtor),
+                        orderSigner.asUnderwriter(debtOrderUndefinedDebtor, false),
                     ).rejects.toThrow(/requires property "debtor"/);
                 });
             });
@@ -455,7 +527,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderMalformedDebtor),
+                        orderSigner.asUnderwriter(debtOrderMalformedDebtor, false),
                     ).rejects.toThrow(/\.debtor does not match pattern/);
                 });
             });
@@ -466,7 +538,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderUndefinedPrincipal),
+                        orderSigner.asUnderwriter(debtOrderUndefinedPrincipal, false),
                     ).rejects.toThrow(/requires property "principalAmount"/);
                 });
             });
@@ -488,7 +560,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderMissingPrincipalToken),
+                        orderSigner.asUnderwriter(debtOrderMissingPrincipalToken, false),
                     ).rejects.toThrow(/requires property "principalToken"/);
                 });
             });
@@ -499,7 +571,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderMalformedPrincipalToken),
+                        orderSigner.asUnderwriter(debtOrderMalformedPrincipalToken, false),
                     ).rejects.toThrow(/\.principalToken does not match pattern/);
                 });
             });
@@ -510,7 +582,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderUndefinedTermsContract),
+                        orderSigner.asUnderwriter(debtOrderUndefinedTermsContract, false),
                     ).rejects.toThrow(/requires property "termsContract"/);
                 });
             });
@@ -521,7 +593,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderMalformedTermsContract),
+                        orderSigner.asUnderwriter(debtOrderMalformedTermsContract, false),
                     ).rejects.toThrow(/\.termsContract does not match pattern/);
                 });
             });
@@ -532,7 +604,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderUndefinedTermsContractParams),
+                        orderSigner.asUnderwriter(debtOrderUndefinedTermsContractParams, false),
                     ).rejects.toThrow(/requires property "termsContractParameters"/);
                 });
             });
@@ -543,7 +615,7 @@ describe("Order Signer (Unit Tests)", () => {
 
                 test("throws DOES_NOT_CONFORM_TO_SCHEMA error", async () => {
                     await expect(
-                        orderSigner.asUnderwriter(debtOrderMalformedTermsContractParams),
+                        orderSigner.asUnderwriter(debtOrderMalformedTermsContractParams, false),
                     ).rejects.toThrow(/\.termsContractParameters does not match pattern/);
                 });
             });
@@ -555,7 +627,7 @@ describe("Order Signer (Unit Tests)", () => {
 
             test("throws INVALID_SIGNING_KEY error", async () => {
                 await expect(
-                    orderSigner.asUnderwriter(debtOrderWithNullUnderwriter),
+                    orderSigner.asUnderwriter(debtOrderWithNullUnderwriter, false),
                 ).rejects.toThrow(SignerAPIErrors.INVALID_SIGNING_KEY(NULL_ADDRESS));
             });
         });
@@ -567,7 +639,7 @@ describe("Order Signer (Unit Tests)", () => {
 
             test("throws INVALID_SIGNING_KEY error", async () => {
                 await expect(
-                    orderSigner.asUnderwriter(debtOrderWithExternalUnderwriter),
+                    orderSigner.asUnderwriter(debtOrderWithExternalUnderwriter, false),
                 ).rejects.toThrow(
                     SignerAPIErrors.INVALID_SIGNING_KEY(
                         debtOrderWithExternalUnderwriter.underwriter,
@@ -577,10 +649,10 @@ describe("Order Signer (Unit Tests)", () => {
         });
 
         describe("...with underwriter's private key available and unlocked", () => {
-            test("returns valid signature", async () => {
-                const ecdsaSignature = await orderSigner.asUnderwriter(debtOrder);
+            let underwriterCommitmentHash: string;
 
-                const debtOrderHash = Web3Utils.soliditySHA3(
+            beforeAll(() => {
+                underwriterCommitmentHash = Web3Utils.soliditySHA3(
                     debtOrder.kernelVersion,
                     Web3Utils.soliditySHA3(
                         debtOrder.issuanceVersion,
@@ -596,14 +668,47 @@ describe("Order Signer (Unit Tests)", () => {
                     debtOrder.principalToken,
                     debtOrder.expirationTimestampInSec,
                 );
+            });
 
-                expect(
-                    signatureUtils.isValidSignature(
-                        debtOrderHash,
-                        ecdsaSignature,
-                        debtOrder.underwriter,
-                    ),
-                ).toBeTruthy();
+            describe("on signing client that expects hashed message w/ personal message prefix", () => {
+                test("returns valid signature", async () => {
+                    const ecdsaSignature = await orderSigner.asUnderwriter(debtOrder, true);
+
+                    // Given that our test environment (namely, Ganache) is a client that
+                    // prepends the personal message prefix on the user's behalf, the correctly
+                    // produced signature in this test environment will actually
+                    // redundantly prepend a personal message prefix to the payload
+                    // twice.  Thus, to test for correctness as best we can, we redundantly prefix
+                    // and hash the debtOrderHash -- once below, and again in the `isValidSignature`
+                    // mtheod.
+                    const prefixedCommitmentHash = SignatureUtils.addPersonalMessagePrefix(
+                        underwriterCommitmentHash,
+                    );
+
+                    expect(
+                        SignatureUtils.isValidSignature(
+                            prefixedCommitmentHash,
+                            ecdsaSignature,
+                            debtOrder.underwriter,
+                            true,
+                        ),
+                    ).toBeTruthy();
+                });
+            });
+
+            describe("on signing client that adds personal message prefix on user's behalf", () => {
+                test("returns valid signature", async () => {
+                    const ecdsaSignature = await orderSigner.asUnderwriter(debtOrder, false);
+
+                    expect(
+                        SignatureUtils.isValidSignature(
+                            underwriterCommitmentHash,
+                            ecdsaSignature,
+                            debtOrder.underwriter,
+                            true,
+                        ),
+                    ).toBeTruthy();
+                });
             });
         });
     });

--- a/src/invariants/order.ts
+++ b/src/invariants/order.ts
@@ -8,7 +8,7 @@ import {
     TokenTransferProxyContract,
     ERC20Contract,
 } from "../wrappers";
-import { signatureUtils } from "../../utils/signature_utils";
+import { SignatureUtils } from "../../utils/signature_utils";
 import * as moment from "moment";
 import { ContractsAPI } from "../apis";
 
@@ -157,7 +157,7 @@ export class OrderAssertions {
 
         if (transactionOptions.from !== debtOrder.debtor) {
             if (
-                !signatureUtils.isValidSignature(
+                !SignatureUtils.isValidSignature(
                     debtOrderWrapped.getDebtorCommitmentHash(),
                     debtOrder.debtorSignature,
                     debtOrder.debtor,
@@ -179,7 +179,7 @@ export class OrderAssertions {
 
         if (transactionOptions.from !== debtOrder.creditor) {
             if (
-                !signatureUtils.isValidSignature(
+                !SignatureUtils.isValidSignature(
                     debtOrderWrapped.getCreditorCommitmentHash(),
                     debtOrder.creditorSignature,
                     debtOrder.creditor,
@@ -201,7 +201,7 @@ export class OrderAssertions {
 
         if (transactionOptions.from !== debtOrder.underwriter) {
             if (
-                !signatureUtils.isValidSignature(
+                !SignatureUtils.isValidSignature(
                     debtOrderWrapped.getUnderwriterCommitmentHash(),
                     debtOrder.underwriterSignature,
                     debtOrder.underwriter,

--- a/utils/signature_utils.ts
+++ b/utils/signature_utils.ts
@@ -19,7 +19,7 @@ export class SignatureUtils {
      *      API adds an Ethereum-specific prefix to message payloads.  This option
      *      specifies whether, in the `isValidSignature`, we want to add the
      *      Ethereum-specifc prefix to the message payload.
-     * @return [description]
+     * @return Whether or not the signature is valid.
      */
     public static isValidSignature(
         data: string,

--- a/utils/signature_utils.ts
+++ b/utils/signature_utils.ts
@@ -8,6 +8,19 @@ import { ECDSASignature } from "../src/types";
  */
 
 export class SignatureUtils {
+    /**
+     * Given a data payload, signature, and a signer's address, returns true
+     * if the given signature is valid.
+     *
+     * @param data                     Data payload
+     * @param signature                Signature
+     * @param signerAddress            The Signer's address
+     * @param addPersonalMessagePrefix In certain circumstances, the `eth_sign`
+     *      API adds an Ethereum-specific prefix to message payloads.  This option
+     *      specifies whether, in the `isValidSignature`, we want to add the
+     *      Ethereum-specifc prefix to the message payload.
+     * @return [description]
+     */
     public static isValidSignature(
         data: string,
         signature: ECDSASignature,
@@ -36,6 +49,20 @@ export class SignatureUtils {
         }
     }
 
+    /**
+     * Applies an Ethereum-specific prefix to the message payload we intend on signing,
+     * as per the `eth_sign` specification in the JSON-RPC wiki:
+     *
+     * https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
+     *
+     * This must *sometimes* be manually done by our libraries because certain signing
+     * clients (e.g. Metamask) do not adhere to the `eth_sign` specification described
+     * above.
+     *
+     * @param messageHashHex The raw hex message payload
+     * @return Message hashed as per how certain clients (i.e. Metamask)
+     *  expect to ingest messages in `eth_sign`
+     */
     public static addPersonalMessagePrefix(messageHashHex: string): string {
         const messageHashBuffer = ethUtil.toBuffer(messageHashHex);
         const prefixedMessageHashBuffer = ethUtil.hashPersonalMessage(messageHashBuffer);

--- a/utils/signature_utils.ts
+++ b/utils/signature_utils.ts
@@ -1,19 +1,30 @@
-import * as ethUtil from 'ethereumjs-util';
+import * as ethUtil from "ethereumjs-util";
 
-import { ECDSASignature } from '../src/types';
+import { ECDSASignature } from "../src/types";
 
 /*
  * Ver batim copied, with slight modifications, from the wonderful 0x.js project codebase:
  * https://github.com/0xProject/0x.js
  */
 
-export const signatureUtils = {
-    isValidSignature(data: string, signature: ECDSASignature, signerAddress: string): boolean {
-        const dataBuff = ethUtil.toBuffer(data);
-        const msgHashBuff = ethUtil.hashPersonalMessage(dataBuff);
+export class SignatureUtils {
+    public static isValidSignature(
+        data: string,
+        signature: ECDSASignature,
+        signerAddress: string,
+        addPersonalMessagePrefix: boolean = true,
+    ): boolean {
+        let messageHash = data;
+
+        if (addPersonalMessagePrefix) {
+            messageHash = SignatureUtils.addPersonalMessagePrefix(messageHash);
+        }
+
+        const messageHashBuff = ethUtil.toBuffer(messageHash);
+
         try {
             const pubKey = ethUtil.ecrecover(
-                msgHashBuff,
+                messageHashBuff,
                 signature.v,
                 ethUtil.toBuffer(signature.r),
                 ethUtil.toBuffer(signature.s),
@@ -23,9 +34,16 @@ export const signatureUtils = {
         } catch (err) {
             return false;
         }
-    },
+    }
 
-    parseSignatureHexAsVRS(signatureHex: string): ECDSASignature {
+    public static addPersonalMessagePrefix(messageHashHex: string): string {
+        const messageHashBuffer = ethUtil.toBuffer(messageHashHex);
+        const prefixedMessageHashBuffer = ethUtil.hashPersonalMessage(messageHashBuffer);
+
+        return ethUtil.bufferToHex(prefixedMessageHashBuffer);
+    }
+
+    public static parseSignatureHexAsVRS(signatureHex: string): ECDSASignature {
         const signatureBuffer = ethUtil.toBuffer(signatureHex);
         let v = signatureBuffer[0];
         if (v < 27) {
@@ -39,9 +57,9 @@ export const signatureUtils = {
             s: ethUtil.bufferToHex(s),
         };
         return ECDSASignature;
-    },
+    }
 
-    parseSignatureHexAsRSV(signatureHex: string): ECDSASignature {
+    public static parseSignatureHexAsRSV(signatureHex: string): ECDSASignature {
         const { v, r, s } = ethUtil.fromRpcSig(signatureHex);
         const ECDSASignature: ECDSASignature = {
             v,
@@ -49,25 +67,15 @@ export const signatureUtils = {
             s: ethUtil.bufferToHex(s),
         };
         return ECDSASignature;
-    },
-
-    convertToHexRSV(signature: ECDSASignature): string {
-        const { r, s, v } = signature;
-        return [
-            "0x",
-            r,
-            s,
-            v.toString(16),
-        ].join("");
-    },
-
-    convertToHexVRS(signature: ECDSASignature): string {
-        const { v, r, s } = signature;
-        return [
-            "0x",
-            v.toString(16),
-            r,
-            s,
-        ].join("");
     }
-};
+
+    public static convertToHexRSV(signature: ECDSASignature): string {
+        const { r, s, v } = signature;
+        return ["0x", r, s, v.toString(16)].join("");
+    }
+
+    public static convertToHexVRS(signature: ECDSASignature): string {
+        const { v, r, s } = signature;
+        return ["0x", v.toString(16), r, s].join("");
+    }
+}


### PR DESCRIPTION
This PR introduces the following changes:

- Add a `shouldAddPersonalMessagePrefix` argument to all relevant signer API methods, to give users the flexibility to interact with different types of signer clients (i.e. Metamask vs. Geth)
- Patch tests associated with this.

The rationale for this has to do with the idiosyncrasies around how Metamask, Geth, Parity, and TestRPC all handle `eth_sign` messages. The crucially important factor seems to be that Geth / Parity / TestRPC all modify signing payloads on users behalf to include data that helps prevent chosen ciphertext attacks (see [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign)), whereas Metamask does *not* do this.

It seems like many of these idiosyncracies will no longer be relevant once ERC721 is finalized.  Until then, though, we opt to give users some agency on this front (this is similarly [how the 0x folks are dealing with this thorn](https://github.com/0xProject/0x-monorepo/blob/development/packages/0x.js/src/0x.ts#L241) for the time being.)