### PR TITLE
feat: add fromDebtRegistryEntry endpoint to adapter

### DIFF
--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -83,7 +83,7 @@ export const SimpleInterestAdapterErrors = {
     MISMATCHED_TERMS_CONTRACT: (termsContract: string) =>
         singleLineString`Terms contract at address ${termsContract} is not
                          a SimpleInterestTermsContract.  As such, this adapter will not
-                         interface with the terms contract as expected.`,
+                         interface with the terms contract as expected`,
 };
 
 const TX_DEFAULTS = { from: NULL_ADDRESS, gas: 0 };

--- a/src/apis/contracts_api.ts
+++ b/src/apis/contracts_api.ts
@@ -47,6 +47,8 @@ export const ContractsError = {
                 address ${principalToken}`,
     CANNOT_FIND_TOKEN_WITH_SYMBOL: (symbol: string) =>
         singleLineString`Could not find token associated with symbol ${symbol}.`,
+    CANNOT_FIND_TOKEN_WITH_INDEX: (index: number) =>
+        singleLineString`Could not find token associated with indedx ${index}.`,
     TERMS_CONTRACT_NOT_FOUND: (tokenAddress: string) =>
         singleLineString`Could not find a terms contract at address ${tokenAddress}`,
 };
@@ -54,7 +56,6 @@ export const ContractsError = {
 export class ContractsAPI {
     private web3: Web3;
     private config: DharmaConfig;
-    private termsContracts: { [contractAddress: string]: ContractWrapper };
 
     private cache: { [contractName: string]: ContractWrapper };
 
@@ -364,7 +365,13 @@ export class ContractsAPI {
     public async getTokenSymbolByIndexAsync(index: BigNumber): Promise<string> {
         const tokenRegistryContract = await this.loadTokenRegistry();
 
-        return tokenRegistryContract.getTokenSymbolByIndex.callAsync(index);
+        const symbol = await tokenRegistryContract.getTokenSymbolByIndex.callAsync(index);
+
+        if (symbol === "") {
+            throw new Error(ContractsError.CANNOT_FIND_TOKEN_WITH_INDEX(index));
+        }
+
+        return symbol;
     }
 
     public async loadTokenBySymbolAsync(

--- a/src/apis/contracts_api.ts
+++ b/src/apis/contracts_api.ts
@@ -48,7 +48,7 @@ export const ContractsError = {
     CANNOT_FIND_TOKEN_WITH_SYMBOL: (symbol: string) =>
         singleLineString`Could not find token associated with symbol ${symbol}.`,
     CANNOT_FIND_TOKEN_WITH_INDEX: (index: number) =>
-        singleLineString`Could not find token associated with indedx ${index}.`,
+        singleLineString`Could not find token associated with index ${index}.`,
     TERMS_CONTRACT_NOT_FOUND: (tokenAddress: string) =>
         singleLineString`Could not find a terms contract at address ${tokenAddress}`,
 };


### PR DESCRIPTION
This PR introduces the following changes:

- Adds a `fromDebtRegistryEntry` endpoint to the SimpleInterestLoanAdapter.
- Adds tests for the new endpoint.