### PR TITLE
Lay groundwork for CollateralizedSimpleInterest Adapter

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,2 +1,6 @@
 # .prettierrc
-trailingComma: "all"
+printWidth: 100
+parser: typescript
+tabWidth: 4
+trailingComma: all
+arrowParens: always

--- a/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
@@ -1,3 +1,13 @@
+// Given that we rely on having access to the deployed Dharma smart contracts,
+// we unmock the Dharma smart contracts artifacts package to pull the most recently
+// deployed contracts on the current network.
+jest.unmock("@dharmaprotocol/contracts");
+
+// Unmock the "fs-extra" package in order to give us
+// access to the deployed TokenRegistry on the
+// test chain.
+jest.unmock("fs-extra");
+
 // libraries
 import * as Web3 from "web3";
 import * as moment from "moment";
@@ -13,7 +23,7 @@ import {
     DebtKernelContract,
     ERC20Contract,
     RepaymentRouterContract,
-    SimpleInterestTermsContractContract,
+    CollateralizedSimpleInterestTermsContractContract,
 } from "src/wrappers";
 
 // types
@@ -27,6 +37,10 @@ import {
     CollateralizedTermsContractParameters,
     CollateralizedSimpleInterestLoanOrder,
 } from "src/adapters/collateralized_simple_interest_loan_adapter";
+import {
+    SimpleInterestLoanAdapter,
+    SimpleInterestAdapterErrors,
+} from "src/adapters/simple_interest_loan_adapter";
 
 import { ContractsAPI, ContractsError } from "src/apis/contracts_api";
 
@@ -42,6 +56,10 @@ const collateralizedSimpleInterestLoanAdapter = new CollateralizedSimpleInterest
 const collateralizedLoanTerms = new CollateralizedLoanTerms(web3, contracts);
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
+
+const REP_TOKEN_SYMBOL = "REP";
+const ZRX_TOKEN_SYMBOL = "ZRX";
+const MKR_TOKEN_SYMBOL = "MKR";
 
 interface Scenario {
     unpackedParams: CollateralizedTermsContractParameters;
@@ -235,6 +253,412 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                 expect(collateralizedLoanTerms.unpackParameters(scenario_3.packedParams)).toEqual(
                     scenario_3.unpackedParams,
                 );
+            });
+        });
+    });
+});
+
+describe("Collateralized Simple Interest Loan Adapter (Unit Tests)", () => {
+    interface AdapterScenario {
+        debtOrder: DebtOrder.Instance;
+        fullLoanOrder: CollateralizedSimpleInterestLoanOrder;
+        minimalLoanOrder: CollateralizedSimpleInterestLoanOrder;
+        entry: DebtRegistryEntry;
+    }
+
+    let scenario_1: AdapterScenario;
+    let scenario_2: AdapterScenario;
+    let scenario_3: AdapterScenario;
+
+    beforeAll(async () => {
+        const debtKernel = await DebtKernelContract.deployed(web3, TX_DEFAULTS);
+        const repaymentRouter = await RepaymentRouterContract.deployed(web3, TX_DEFAULTS);
+        const termsContract = await contracts.loadCollateralizedSimpleInterestTermsContract(
+            TX_DEFAULTS,
+        );
+
+        const REP_TOKEN = await contracts.loadTokenBySymbolAsync(REP_TOKEN_SYMBOL, TX_DEFAULTS);
+
+        const MKR_TOKEN = await contracts.loadTokenBySymbolAsync(MKR_TOKEN_SYMBOL, TX_DEFAULTS);
+
+        const ZRX_TOKEN = await contracts.loadTokenBySymbolAsync(ZRX_TOKEN_SYMBOL, TX_DEFAULTS);
+
+        const principalAmountForScenario1 = new BigNumber(1000 * 10 ** 18);
+        const principalAmountForScenario2 = new BigNumber(12 * 10 ** 18);
+        const principalAmountForScenario3 = new BigNumber(50 * 10 ** 18);
+
+        const debtOrderBase = {
+            ...DebtOrder.DEFAULTS,
+            kernelVersion: debtKernel.address,
+            issuanceVersion: repaymentRouter.address,
+            termsContract: termsContract.address,
+        };
+
+        const debtOrderForScenario1 = {
+            ...debtOrderBase,
+            principalAmount: principalAmountForScenario1,
+            principalToken: REP_TOKEN.address,
+            termsContractParameters:
+                "0x000000003635c9adc5dea000000003e8300020200000008ac7230489e800005a",
+        };
+
+        const debtOrderForScenario2 = {
+            ...debtOrderBase,
+            principalAmount: principalAmountForScenario2,
+            principalToken: MKR_TOKEN.address,
+            termsContractParameters:
+                "0x0100000000a688906bd8b000000004b0400030000000004563918244f4000078",
+        };
+
+        const debtOrderForScenario3 = {
+            ...debtOrderBase,
+            principalAmount: principalAmountForScenario3,
+            principalToken: ZRX_TOKEN.address,
+            termsContractParameters:
+                "0x0200000002b5e3af16b18800000007d02000a010000001bc16d674ec8000000a",
+        };
+
+        const loanOrderParamsForScenario1 = {
+            principalTokenSymbol: REP_TOKEN_SYMBOL,
+            principalAmount: principalAmountForScenario1,
+            interestRate: new BigNumber(0.1),
+            amortizationUnit: SimpleInterestLoanAdapter.Installments.MONTHLY,
+            termLength: new BigNumber(2),
+            collateralTokenSymbol: ZRX_TOKEN_SYMBOL,
+            collateralAmount: new BigNumber(10 * 10 ** 18),
+            gracePeriodInDays: new BigNumber(90),
+        };
+
+        const loanOrderParamsForScenario2 = {
+            principalTokenSymbol: MKR_TOKEN_SYMBOL,
+            principalAmount: principalAmountForScenario2,
+            interestRate: new BigNumber(0.12),
+            amortizationUnit: SimpleInterestLoanAdapter.Installments.YEARLY,
+            termLength: new BigNumber(3),
+            collateralTokenSymbol: REP_TOKEN_SYMBOL,
+            collateralAmount: new BigNumber(5 * 10 ** 18),
+            gracePeriodInDays: new BigNumber(120),
+        };
+
+        const loanOrderParamsForScenario3 = {
+            principalTokenSymbol: ZRX_TOKEN_SYMBOL,
+            principalAmount: principalAmountForScenario3,
+            interestRate: new BigNumber(0.2),
+            amortizationUnit: SimpleInterestLoanAdapter.Installments.WEEKLY,
+            termLength: new BigNumber(10),
+            collateralTokenSymbol: MKR_TOKEN_SYMBOL,
+            collateralAmount: new BigNumber(32 * 10 ** 18),
+            gracePeriodInDays: new BigNumber(10),
+        };
+
+        const debtRegistryEntryBase = {
+            version: repaymentRouter.address,
+            beneficiary: ACCOUNTS[0].address,
+            underwriter: ACCOUNTS[1].address,
+            underwriterRiskRating: Units.percent(0.1),
+            termsContract: termsContract.address,
+            issuanceBlockTimestamp: new BigNumber(moment().unix()),
+        };
+
+        scenario_1 = {
+            debtOrder: debtOrderForScenario1,
+            fullLoanOrder: {
+                ...debtOrderForScenario1,
+                ...loanOrderParamsForScenario1,
+            },
+            minimalLoanOrder: loanOrderParamsForScenario1,
+            entry: {
+                ...debtRegistryEntryBase,
+                termsContractParameters: debtOrderForScenario1.termsContractParameters,
+            },
+        };
+        scenario_2 = {
+            debtOrder: debtOrderForScenario2,
+            fullLoanOrder: {
+                ...debtOrderForScenario2,
+                ...loanOrderParamsForScenario2,
+            },
+            minimalLoanOrder: loanOrderParamsForScenario2,
+            entry: {
+                ...debtRegistryEntryBase,
+                termsContractParameters: debtOrderForScenario2.termsContractParameters,
+            },
+        };
+        scenario_3 = {
+            debtOrder: debtOrderForScenario3,
+            fullLoanOrder: {
+                ...debtOrderForScenario3,
+                ...loanOrderParamsForScenario3,
+            },
+            minimalLoanOrder: loanOrderParamsForScenario3,
+            entry: {
+                ...debtRegistryEntryBase,
+                termsContractParameters: debtOrderForScenario3.termsContractParameters,
+            },
+        };
+    });
+
+    describe("#toDebtOrder", () => {
+        describe("collateralized simple interest loan's required parameter is missing or malformed", () => {
+            describe("`collateralTokenSymbol` is missing", () => {
+                test("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.toDebtOrder({
+                            ...scenario_1.minimalLoanOrder,
+                            collateralTokenSymbol: undefined,
+                        }),
+                    ).rejects.toThrow('instance requires property "collateralTokenSymbol"');
+                });
+            });
+            describe("`collateralTokenSymbol` is not tracked by Token Registry", () => {
+                test("should throw CANNOT_FIND_TOKEN_WITH_SYMBOL", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.toDebtOrder({
+                            ...scenario_1.minimalLoanOrder,
+                            collateralTokenSymbol: "EOS", // EOS is not tracked in our test env's registry
+                        }),
+                    ).rejects.toThrow(ContractsError.CANNOT_FIND_TOKEN_WITH_SYMBOL("EOS"));
+                });
+            });
+            describe("`collateralAmount` is missing", async () => {
+                test("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.toDebtOrder({
+                            ...scenario_1.minimalLoanOrder,
+                            collateralAmount: undefined,
+                        }),
+                    ).rejects.toThrow('instance requires property "collateralAmount"');
+                });
+            });
+            describe("`gracePeriodInDays` is missing", async () => {
+                test("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.toDebtOrder({
+                            ...scenario_1.minimalLoanOrder,
+                            gracePeriodInDays: undefined,
+                        }),
+                    ).rejects.toThrow('instance requires property "gracePeriodInDays"');
+                });
+            });
+        });
+
+        describe("collateralized simple interest loan's required parameters are present and well-formed ", () => {
+            describe("Scenario #1", () => {
+                test("should return debt order with correctly packed values", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.toDebtOrder(
+                            scenario_1.minimalLoanOrder,
+                        ),
+                    ).resolves.toEqual(scenario_1.debtOrder);
+                });
+            });
+            describe("Scenario #2", () => {
+                test("should return debt order with correctly packed values", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.toDebtOrder(
+                            scenario_2.minimalLoanOrder,
+                        ),
+                    ).resolves.toEqual(scenario_2.debtOrder);
+                });
+            });
+            describe("Scenario #3", () => {
+                test("should return debt order with correctly packed values", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.toDebtOrder(
+                            scenario_3.minimalLoanOrder,
+                        ),
+                    ).resolves.toEqual(scenario_3.debtOrder);
+                });
+            });
+        });
+    });
+
+    describe("#fromDebtOrder()", () => {
+        describe("argument does not conform to the DebtOrderWithTermsSpecified schema", () => {
+            describe("malformed terms contract", () => {
+                test("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtOrder({
+                            ...scenario_1.debtOrder,
+                            termsContract: "invalid terms contract",
+                        }),
+                    ).rejects.toThrow("instance.termsContract does not match pattern");
+                });
+            });
+
+            describe("missing termsContract", () => {
+                test("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtOrder({
+                            ...scenario_1.debtOrder,
+                            termsContract: undefined,
+                        }),
+                    ).rejects.toThrow('instance requires property "termsContract"');
+                });
+            });
+
+            describe("missing termsContractParameters", () => {
+                test("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtOrder({
+                            ...scenario_1.debtOrder,
+                            termsContractParameters: undefined,
+                        }),
+                    ).rejects.toThrow('instance requires property "termsContractParameters"');
+                });
+            });
+
+            describe("missing principalAmount", async () => {
+                test("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtOrder({
+                            ...scenario_1.debtOrder,
+                            principalAmount: undefined,
+                        }),
+                    ).rejects.toThrow('instance requires property "principalAmount"');
+                });
+            });
+
+            describe("missing principalToken", async () => {
+                test("should throw DOES_NOT_CONFORM_TO_SCHEMA", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtOrder({
+                            ...scenario_1.debtOrder,
+                            principalToken: undefined,
+                        }),
+                    ).rejects.toThrow('instance requires property "principalToken"');
+                });
+            });
+        });
+
+        describe("terms contract does not match principal token's associated `CollateralizedSimpleInterestTermsContract`", () => {
+            test("should throw MISMATCHED_TOKEN_SYMBOL", async () => {
+                await expect(
+                    collateralizedSimpleInterestLoanAdapter.fromDebtOrder({
+                        ...scenario_1.debtOrder,
+                        // the principal token index is encoded as 1 (which is MKR) instead of 0.
+                        termsContractParameters:
+                            "0x010000003635c9adc5dea000000003e8300020200000008ac7230489e800005a",
+                    }),
+                ).rejects.toThrow(
+                    CollateralizedAdapterErrors.MISMATCHED_TOKEN_SYMBOL(
+                        scenario_1.debtOrder.principalToken,
+                        MKR_TOKEN_SYMBOL,
+                    ),
+                );
+            });
+        });
+
+        describe("terms contract params contains token index out of bounds", () => {
+            test("should throw CANNOT_FIND_TOKEN_WITH_INDEX", async () => {
+                await expect(
+                    collateralizedSimpleInterestLoanAdapter.fromDebtOrder({
+                        ...scenario_1.debtOrder,
+                        // the principal token index is encoded as 9, which does not map to any
+                        // token listed in our `TokenRegistry`
+                        termsContractParameters:
+                            "0x090000003635c9adc5dea000000003e8300020200000008ac7230489e800005a",
+                    }),
+                ).rejects.toThrow(ContractsError.CANNOT_FIND_TOKEN_WITH_INDEX(9));
+            });
+        });
+
+        describe("amortization specified in termsContractParameters is of invalid type", () => {
+            it("should throw INVALID_AMORTIZATION_UNIT_TYPE", async () => {
+                await expect(
+                    collateralizedSimpleInterestLoanAdapter.fromDebtOrder({
+                        ...scenario_1.debtOrder,
+                        // The amortization unit is encoded as 6 (which is invalid) instead of 3.
+                        termsContractParameters:
+                            "0x000000003635c9adc5dea000000003e8600020200000008ac7230489e800005a",
+                    }),
+                ).rejects.toThrow(SimpleInterestAdapterErrors.INVALID_AMORTIZATION_UNIT_TYPE());
+            });
+        });
+
+        describe("debt order is valid and well-formed", () => {
+            describe("Scenario #1", () => {
+                test("should return `CollateralizedSimpleInterestLoanOrder` with correctly unpacked values", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtOrder(scenario_1.debtOrder),
+                    ).resolves.toEqual(scenario_1.fullLoanOrder);
+                });
+            });
+            describe("Scenario #2", () => {
+                test("should return `CollateralizedSimpleInterestLoanOrder` with correctly unpacked values", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtOrder(scenario_2.debtOrder),
+                    ).resolves.toEqual(scenario_2.fullLoanOrder);
+                });
+            });
+            describe("Scenario #3", () => {
+                test("should return `CollateralizedSimpleInterestLoanOrder` with correctly unpacked values", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtOrder(scenario_3.debtOrder),
+                    ).resolves.toEqual(scenario_3.fullLoanOrder);
+                });
+            });
+        });
+    });
+    describe("#fromDebtRegistryEntry", () => {
+        describe("no principal token tracked at that index", () => {
+            it("should throw CANNOT_FIND_TOKEN_WITH_INDEX", async () => {
+                await expect(
+                    collateralizedSimpleInterestLoanAdapter.fromDebtRegistryEntry({
+                        ...scenario_1.entry,
+                        // Our test environment does not track a token at index 5 (which is packed
+                        // into the first byte of the parameters)
+                        termsContractParameters:
+                            "0x05000000000de0b6b3a764000000057820002000000000000000000000000000",
+                    }),
+                ).rejects.toThrow(ContractsError.CANNOT_FIND_TOKEN_WITH_INDEX(5));
+            });
+        });
+
+        describe("refers to incorrect terms contract", () => {
+            test("should throw MISMATCHED_TERMS_CONTRACT", async () => {
+                // We choose an arbitrary address to represent
+                // a different terms contract's address.
+                const INVALID_ADDRESS = ACCOUNTS[3].address;
+
+                await expect(
+                    collateralizedSimpleInterestLoanAdapter.fromDebtRegistryEntry({
+                        ...scenario_1.entry,
+                        termsContract: INVALID_ADDRESS,
+                    }),
+                ).rejects.toThrow(
+                    CollateralizedAdapterErrors.MISMATCHED_TERMS_CONTRACT(INVALID_ADDRESS),
+                );
+            });
+        });
+
+        describe("entry parameters are valid", () => {
+            describe("Scenario #1:", () => {
+                test("should return correct collateralized simple interest loan order", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtRegistryEntry(
+                            scenario_1.entry,
+                        ),
+                    ).resolves.toEqual(scenario_1.minimalLoanOrder);
+                });
+            });
+            describe("Scenario #2:", () => {
+                test("should return correct collateralized simple interest loan order", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtRegistryEntry(
+                            scenario_2.entry,
+                        ),
+                    ).resolves.toEqual(scenario_2.minimalLoanOrder);
+                });
+            });
+            describe("Scenario #3:", () => {
+                test("should return correct collateralized simple interest loan order", async () => {
+                    await expect(
+                        collateralizedSimpleInterestLoanAdapter.fromDebtRegistryEntry(
+                            scenario_3.entry,
+                        ),
+                    ).resolves.toEqual(scenario_3.minimalLoanOrder);
+                });
             });
         });
     });

--- a/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
@@ -1,0 +1,241 @@
+// libraries
+import * as Web3 from "web3";
+import * as moment from "moment";
+
+// utils
+import { BigNumber } from "utils/bignumber";
+import { ACCOUNTS } from "../../accounts";
+import * as Units from "utils/units";
+import { Web3Utils } from "utils/web3_utils";
+
+// wrappers
+import {
+    DebtKernelContract,
+    ERC20Contract,
+    RepaymentRouterContract,
+    SimpleInterestTermsContractContract,
+} from "src/wrappers";
+
+// types
+import { DebtOrder, DebtRegistryEntry } from "src/types";
+
+// adapters
+import {
+    CollateralizedSimpleInterestLoanAdapter,
+    CollateralizedLoanTerms,
+    CollateralizedAdapterErrors,
+    CollateralizedTermsContractParameters,
+    CollateralizedSimpleInterestLoanOrder,
+} from "src/adapters/collateralized_simple_interest_loan_adapter";
+
+import { ContractsAPI, ContractsError } from "src/apis/contracts_api";
+
+const provider = new Web3.providers.HttpProvider("http://localhost:8545");
+const web3 = new Web3(provider);
+const web3Utils = new Web3Utils(web3);
+const contracts = new ContractsAPI(web3);
+
+const collateralizedSimpleInterestLoanAdapter = new CollateralizedSimpleInterestLoanAdapter(
+    web3,
+    contracts,
+);
+const collateralizedLoanTerms = new CollateralizedLoanTerms(web3, contracts);
+
+const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
+
+interface Scenario {
+    unpackedParams: CollateralizedTermsContractParameters;
+    packedParams: string;
+}
+
+describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
+    let snapshotId: number;
+
+    beforeEach(async () => {
+        snapshotId = await web3Utils.saveTestSnapshot();
+    });
+
+    afterEach(async () => {
+        await web3Utils.revertToSnapshot(snapshotId);
+    });
+
+    const scenario_1: Scenario = {
+        unpackedParams: {
+            collateralTokenIndex: new BigNumber(0),
+            collateralAmount: new BigNumber(3.5 * 10 ** 18),
+            gracePeriodInDays: new BigNumber(5),
+        },
+        packedParams: "0x000000000000000000000000000000000000000000000030927f74c9de000005",
+    };
+
+    const scenario_2: Scenario = {
+        unpackedParams: {
+            collateralTokenIndex: new BigNumber(1),
+            collateralAmount: new BigNumber(723489020 * 10 ** 18),
+            gracePeriodInDays: new BigNumber(30),
+        },
+        packedParams: "0x00000000000000000000000000000000000000125674c25cd7f81d067000001e",
+    };
+
+    const scenario_3: Scenario = {
+        unpackedParams: {
+            collateralTokenIndex: new BigNumber(8),
+            collateralAmount: new BigNumber(1212234234 * 10 ** 18),
+            gracePeriodInDays: new BigNumber(90),
+        },
+        packedParams: "0x0000000000000000000000000000000000000083eabc9580d20c1abba800005a",
+    };
+
+    describe("#packParameters", () => {
+        describe("...with invalid collateral token index", () => {
+            test("should throw INVALID_TOKEN_INDEX error", () => {
+                const invalidCollateralTokenIndex = new BigNumber(300);
+
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario_1.unpackedParams,
+                        collateralTokenIndex: invalidCollateralTokenIndex,
+                    });
+                }).toThrow(
+                    CollateralizedAdapterErrors.INVALID_TOKEN_INDEX(invalidCollateralTokenIndex),
+                );
+            });
+        });
+        describe("...with collateral amount > 2^92 - 1", () => {
+            test("should throw COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario_1.unpackedParams,
+                        collateralAmount: new BigNumber(3.5 * 10 ** 38),
+                    });
+                }).toThrow(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM());
+            });
+        });
+        describe("...with collateral amount < 0", () => {
+            test("should throw COLLATERAL_AMOUNT_IS_NEGATIVE error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario_1.unpackedParams,
+                        collateralAmount: new BigNumber(-1),
+                    });
+                }).toThrow(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
+            });
+        });
+        describe("...with collateral amount containing decimals", () => {
+            test("should throw INVALID_DECIMAL_VALUE error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario_1.unpackedParams,
+                        collateralAmount: new BigNumber(100.4567),
+                    });
+                }).toThrowError(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+            });
+        });
+        describe("...with grace period in days < 0", () => {
+            test("should throw GRACE_PERIOD_IS_NEGATIVE error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario_1.unpackedParams,
+                        gracePeriodInDays: new BigNumber(-1),
+                    });
+                }).toThrowError(CollateralizedAdapterErrors.GRACE_PERIOD_IS_NEGATIVE());
+            });
+        });
+        describe("...with grace period in days > 255", () => {
+            test("should throw GRACE_PERIOD_EXCEEDS_MAXIMUM error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario_1.unpackedParams,
+                        gracePeriodInDays: new BigNumber(256),
+                    });
+                }).toThrowError(CollateralizedAdapterErrors.GRACE_PERIOD_EXCEEDS_MAXIMUM());
+            });
+        });
+        describe("...with grace period containing decimals", () => {
+            test("should throw INVALID_DECIMAL_VALUE error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario_1.unpackedParams,
+                        gracePeriodInDays: new BigNumber(1.567),
+                    });
+                }).toThrowError(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+            });
+        });
+        describe("...with valid collateral token index, collateral amount, and grace period in days", () => {
+            describe("Scenario #1", () => {
+                test("should return correctly packed parameters", () => {
+                    expect(
+                        collateralizedLoanTerms.packParameters(scenario_1.unpackedParams),
+                    ).toEqual(scenario_1.packedParams);
+                });
+            });
+            describe("Scenario #2", () => {
+                test("should return correctly packed parameters", () => {
+                    expect(
+                        collateralizedLoanTerms.packParameters(scenario_2.unpackedParams),
+                    ).toEqual(scenario_2.packedParams);
+                });
+            });
+            describe("Scenario #3", () => {
+                test("should return correctly packed parameters", () => {
+                    expect(
+                        collateralizedLoanTerms.packParameters(scenario_3.unpackedParams),
+                    ).toEqual(scenario_3.packedParams);
+                });
+            });
+        });
+    });
+
+    describe("#unpackParameters", () => {
+        describe("...with value that has too few bytes", () => {
+            const termsContractParameters = "0x" + "f".repeat(63);
+
+            test("should throw INVALID_PACKED_PARAMETERS error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.unpackParameters(termsContractParameters);
+                }).toThrowError(/Expected packedParams to conform to schema \/Bytes32/);
+            });
+        });
+        describe("...with value that has too many bytes", () => {
+            const termsContractParameters = "0x" + "f".repeat(65);
+
+            test("should throw INVALID_PACKED_PARAMETERS error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.unpackParameters(termsContractParameters);
+                }).toThrowError(/Expected packedParams to conform to schema \/Bytes32/);
+            });
+        });
+        describe("...with value that includes non-hexadecimal characters", () => {
+            const termsContractParameters = "0x" + "z".repeat(64);
+
+            test("should throw INVALID_PACKED_PARAMETERS error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.unpackParameters(termsContractParameters);
+                }).toThrowError(/Expected packedParams to conform to schema \/Bytes32/);
+            });
+        });
+    });
+    describe("...with valid termsContractParameters string", () => {
+        describe("Scenario #1", () => {
+            test("should return correctly unpacked parameters", () => {
+                expect(collateralizedLoanTerms.unpackParameters(scenario_1.packedParams)).toEqual(
+                    scenario_1.unpackedParams,
+                );
+            });
+        });
+        describe("Scenario #2", () => {
+            test("should return correctly unpacked parameters", () => {
+                expect(collateralizedLoanTerms.unpackParameters(scenario_2.packedParams)).toEqual(
+                    scenario_2.unpackedParams,
+                );
+            });
+        });
+        describe("Scenario #3", () => {
+            test("should return correctly unpacked parameters", () => {
+                expect(collateralizedLoanTerms.unpackParameters(scenario_3.packedParams)).toEqual(
+                    scenario_3.unpackedParams,
+                );
+            });
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "main": "dist/dharma.umd.js",
     "module": "dist/lib/src/index.js",
     "typings": "dist/types/src/index.d.ts",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "author": "Nadav Hollander <nadav@dharma.io>",
     "repository": {
         "type": "git",
@@ -25,7 +23,8 @@
         "start": "rollup -c rollup.config.ts -w",
         "chain": "bash scripts/init_chain.sh",
         "test": "jest --runInBand",
-        "docs": "typedoc --theme markdown --mdHideSources --name dharma.js --excludePrivate --excludeExternals --excludeProtected --hideGenerator --target ES6 --out generated_docs/ src/apis",
+        "docs":
+            "typedoc --theme markdown --mdHideSources --name dharma.js --excludePrivate --excludeExternals --excludeProtected --hideGenerator --target ES6 --out generated_docs/ src/apis",
         "test:watch": "jest --watch --runInBand",
         "test:prod": "npm run lint && npm run test -- --coverage --no-cache --runInBand",
         "deploy-docs": "ts-node tools/gh-pages-publish",
@@ -34,13 +33,11 @@
         "semantic-release": "semantic-release pre && npm publish && semantic-release post",
         "semantic-release-prepare": "ts-node tools/semantic-release-prepare",
         "precommit": "lint-staged",
-        "commitmsg": "commitlint -e $GIT_PARAMS"
+        "commitmsg": "commitlint -e $GIT_PARAMS",
+        "prettify": "prettier --write {src,__test__,__mocks__}/**/*.ts"
     },
     "lint-staged": {
-        "{src,__test__,__mocks__}/**/*.ts": [
-            "prettier --write",
-            "git add"
-        ]
+        "{src,__test__,__mocks__}/**/*.ts": ["prettier --write"]
     },
     "config": {
         "commitizen": {
@@ -48,7 +45,8 @@
         },
         "validate-commit-msg": {
             "types": "conventional-commit-types",
-            "helpMessage": "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
+            "helpMessage":
+                "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
         }
     },
     "jest": {
@@ -56,18 +54,9 @@
             ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
         },
         "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-        "moduleFileExtensions": [
-            "ts",
-            "tsx",
-            "js"
-        ],
-        "modulePaths": [
-            "<rootDir>/"
-        ],
-        "coveragePathIgnorePatterns": [
-            "/node_modules/",
-            "/test/"
-        ],
+        "moduleFileExtensions": ["ts", "tsx", "js"],
+        "modulePaths": ["<rootDir>/"],
+        "coveragePathIgnorePatterns": ["/node_modules/", "/test/"],
         "coverageThreshold": {
             "global": {
                 "branches": 40,

--- a/src/adapters/base_adapter.ts
+++ b/src/adapters/base_adapter.ts
@@ -1,6 +1,0 @@
-import { DebtOrder } from "../types";
-
-export abstract class BaseAdapter {
-    public abstract async generateAsync(params: object): Promise<DebtOrder.Instance>;
-    public abstract async validateAsync(debtOrder: DebtOrder.Instance): Promise<void>;
-}

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -9,6 +9,14 @@ export interface CollateralizedTermsContractParameters {
     gracePeriodInDays: BigNumber;
 }
 
+export namespace TermsContractParameters {
+    export function bitShiftLeft(target: BigNumber, numPlaces: number): BigNumber {
+        const binaryTargetString = target.toString(2);
+        const binaryTargetStringShifted = binaryTargetString + "0".repeat(numPlaces);
+        return new BigNumber(binaryTargetStringShifted, 2);
+    }
+}
+
 export class CollateralizedLoanTerms {
     private assert: Assertions;
 
@@ -19,20 +27,17 @@ export class CollateralizedLoanTerms {
     public packParameters(params: CollateralizedTermsContractParameters): string {
         const { collateralTokenIndex, collateralAmount, gracePeriodInDays } = params;
 
-        const collateralTokenIndexShifted = this.bitShiftLeft(collateralTokenIndex, 100);
-        const collateralAmountShifted = this.bitShiftLeft(collateralAmount, 8);
-        const gracePeriodInDaysShifted = this.bitShiftLeft(gracePeriodInDays, 0);
+        const collateralTokenIndexShifted = TermsContractParameters.bitShiftLeft(
+            collateralTokenIndex,
+            100,
+        );
+        const collateralAmountShifted = TermsContractParameters.bitShiftLeft(collateralAmount, 8);
+        const gracePeriodInDaysShifted = TermsContractParameters.bitShiftLeft(gracePeriodInDays, 0);
 
         const baseTenParameters = collateralTokenIndexShifted
             .plus(collateralAmountShifted)
             .plus(gracePeriodInDaysShifted);
 
         return `0x${baseTenParameters.toString(16).padStart(64, "0")}`;
-    }
-
-    private bitShiftLeft(target: BigNumber, numPlaces: number): BigNumber {
-        const binaryTargetString = target.toString(2);
-        const binaryTargetStringShifted = binaryTargetString + "0".repeat(numPlaces);
-        return new BigNumber(binaryTargetStringShifted, 2);
     }
 }

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -66,6 +66,20 @@ export class CollateralizedLoanTerms {
         return `0x${baseTenParameters.toString(16).padStart(64, "0")}`;
     }
 
+    public unpackParameters(packedParams: string): CollateralizedTermsContractParameters {
+        this.assert.schema.bytes32("packedParams", packedParams);
+
+        const collateralTokenIndexHex = `0x${packedParams.substr(39, 2)}`;
+        const collateralAmountHex = `0x${packedParams.substr(41, 23)}`;
+        const gracePeriodInDaysHex = `0x${packedParams.substr(64, 2)}`;
+
+        return {
+            collateralTokenIndex: new BigNumber(collateralTokenIndexHex),
+            collateralAmount: new BigNumber(collateralAmountHex),
+            gracePeriodInDays: new BigNumber(gracePeriodInDaysHex),
+        };
+    }
+
     private assertCollateralTokenIndexWithinBounds(collateralTokenIndex: BigNumber) {
         if (collateralTokenIndex.lt(0) || collateralTokenIndex.gt(MAX_COLLATERAL_TOKEN_INDEX_HEX)) {
             throw new Error(CollateralizedAdapterErrors.INVALID_TOKEN_INDEX(collateralTokenIndex));

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -30,6 +30,8 @@ export const CollateralizedAdapterErrors = {
     INVALID_TOKEN_INDEX: (tokenIndex: BigNumber) =>
         singleLineString`Token Registry does not track a token at index
                          ${tokenIndex.toString()}.`,
+    INVALID_COLLATERAL_AMOUNT_VALUE: () =>
+        singleLineString`Collateral amount cannot be negative or greater than 2^92 - 1.`,
 };
 
 export class CollateralizedLoanTerms {
@@ -43,6 +45,7 @@ export class CollateralizedLoanTerms {
         const { collateralTokenIndex, collateralAmount, gracePeriodInDays } = params;
 
         this.assertCollateralTokenIndexWithinBounds(collateralTokenIndex);
+        this.assertCollateralAmountWithinBounds(collateralAmount);
 
         const collateralTokenIndexShifted = TermsContractParameters.bitShiftLeft(
             collateralTokenIndex,
@@ -61,6 +64,12 @@ export class CollateralizedLoanTerms {
     private assertCollateralTokenIndexWithinBounds(collateralTokenIndex: BigNumber) {
         if (collateralTokenIndex.lt(0) || collateralTokenIndex.gt(MAX_COLLATERAL_TOKEN_INDEX_HEX)) {
             throw new Error(CollateralizedAdapterErrors.INVALID_TOKEN_INDEX(collateralTokenIndex));
+        }
+    }
+
+    private assertCollateralAmountWithinBounds(collateralAmount: BigNumber) {
+        if (collateralAmount.lt(0) || collateralAmount.gt(MAX_COLLATERAL_AMOUNT_HEX)) {
+            throw new Error(CollateralizedAdapterErrors.INVALID_COLLATERAL_AMOUNT_VALUE());
         }
     }
 }

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -1,7 +1,38 @@
+import * as Web3 from "web3";
+import { ContractsAPI } from "src/apis";
+import { Assertions } from "src/invariants";
 import { BigNumber } from "utils/bignumber";
 
 export interface CollateralizedTermsContractParameters {
     collateralTokenIndex: BigNumber;
     collateralAmount: BigNumber;
     gracePeriodInDays: BigNumber;
+}
+
+export class CollateralizedLoanTerms {
+    private assert: Assertions;
+
+    constructor(web3: Web3, contracts: ContractsAPI) {
+        this.assert = new Assertions(web3, contracts);
+    }
+
+    public packParameters(params: CollateralizedTermsContractParameters): string {
+        const { collateralTokenIndex, collateralAmount, gracePeriodInDays } = params;
+
+        const collateralTokenIndexShifted = this.bitShiftLeft(collateralTokenIndex, 100);
+        const collateralAmountShifted = this.bitShiftLeft(collateralAmount, 8);
+        const gracePeriodInDaysShifted = this.bitShiftLeft(gracePeriodInDays, 0);
+
+        const baseTenParameters = collateralTokenIndexShifted
+            .plus(collateralAmountShifted)
+            .plus(gracePeriodInDaysShifted);
+
+        return `0x${baseTenParameters.toString(16).padStart(64, "0")}`;
+    }
+
+    private bitShiftLeft(target: BigNumber, numPlaces: number): BigNumber {
+        const binaryTargetString = target.toString(2);
+        const binaryTargetStringShifted = binaryTargetString + "0".repeat(numPlaces);
+        return new BigNumber(binaryTargetStringShifted, 2);
+    }
 }

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -2,6 +2,7 @@ import * as Web3 from "web3";
 import { ContractsAPI } from "src/apis";
 import { Assertions } from "src/invariants";
 import { BigNumber } from "utils/bignumber";
+import * as singleLineString from "single-line-string";
 
 export interface CollateralizedTermsContractParameters {
     collateralTokenIndex: BigNumber;
@@ -16,6 +17,12 @@ export namespace TermsContractParameters {
         return new BigNumber(binaryTargetStringShifted, 2);
     }
 }
+
+export const CollateralizedAdapterErrors = {
+    INVALID_TOKEN_INDEX: (tokenIndex: BigNumber) =>
+        singleLineString`Token Registry does not track a token at index
+                         ${tokenIndex.toString()}.`,
+};
 
 export class CollateralizedLoanTerms {
     private assert: Assertions;

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -42,6 +42,8 @@ export class CollateralizedLoanTerms {
     public packParameters(params: CollateralizedTermsContractParameters): string {
         const { collateralTokenIndex, collateralAmount, gracePeriodInDays } = params;
 
+        this.assertCollateralTokenIndexWithinBounds(collateralTokenIndex);
+
         const collateralTokenIndexShifted = TermsContractParameters.bitShiftLeft(
             collateralTokenIndex,
             100,
@@ -54,5 +56,11 @@ export class CollateralizedLoanTerms {
             .plus(gracePeriodInDaysShifted);
 
         return `0x${baseTenParameters.toString(16).padStart(64, "0")}`;
+    }
+
+    private assertCollateralTokenIndexWithinBounds(collateralTokenIndex: BigNumber) {
+        if (collateralTokenIndex.lt(0) || collateralTokenIndex.gt(MAX_COLLATERAL_TOKEN_INDEX_HEX)) {
+            throw new Error(CollateralizedAdapterErrors.INVALID_TOKEN_INDEX(collateralTokenIndex));
+        }
     }
 }

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -32,6 +32,9 @@ export const CollateralizedAdapterErrors = {
                          ${tokenIndex.toString()}.`,
     INVALID_COLLATERAL_AMOUNT_VALUE: () =>
         singleLineString`Collateral amount cannot be negative or greater than 2^92 - 1.`,
+    GRACE_PERIOD_IS_NEGATIVE: () => singleLineString`The grace period cannot be negative.`,
+    GRACE_PERIOD_EXCEEDS_MAXIMUM: () =>
+        singleLineString`The grace period exceeds the maximum value of 2^8 - 1`,
 };
 
 export class CollateralizedLoanTerms {
@@ -70,6 +73,18 @@ export class CollateralizedLoanTerms {
     private assertCollateralAmountWithinBounds(collateralAmount: BigNumber) {
         if (collateralAmount.lt(0) || collateralAmount.gt(MAX_COLLATERAL_AMOUNT_HEX)) {
             throw new Error(CollateralizedAdapterErrors.INVALID_COLLATERAL_AMOUNT_VALUE());
+        }
+    }
+
+    private assertGracePeriodInDaysWithinBounds(gracePeriodInDays: BigNumber) {
+        // Grace period can't be negative.
+        if (gracePeriodInDays.lt(0)) {
+            throw new Error(CollateralizedAdapterErrors.GRACE_PERIOD_IS_NEGATIVE());
+        }
+
+        // Grace period has a maximum value that cannot be exceeded due to how we pack params.
+        if (gracePeriodInDays.gt(MAX_GRACE_PERIOD_IN_DAYS_HEX)) {
+            throw new Error(CollateralizedAdapterErrors.GRACE_PERIOD_EXCEEDS_MAXIMUM());
         }
     }
 }

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -50,6 +50,7 @@ export class CollateralizedLoanTerms {
 
         this.assertCollateralTokenIndexWithinBounds(collateralTokenIndex);
         this.assertCollateralAmountWithinBounds(collateralAmount);
+        this.assertGracePeriodInDaysWithinBounds(gracePeriodInDays);
 
         const collateralTokenIndexShifted = TermsContractParameters.bitShiftLeft(
             collateralTokenIndex,

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -248,7 +248,7 @@ export class CollateralizedSimpleInterestLoanAdapter {
         );
 
         // Assert that the principal token corresponds to the symbol we've unpacked.
-        this.assertTokenCorrespondsToSymbol(debtOrder.principalToken, principalTokenSymbol);
+        await this.assertTokenCorrespondsToSymbol(debtOrder.principalToken, principalTokenSymbol);
 
         return {
             ...debtOrder,

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -1,0 +1,7 @@
+import { BigNumber } from "utils/bignumber";
+
+export interface CollateralizedTermsContractParameters {
+    collateralTokenIndex: BigNumber;
+    collateralAmount: BigNumber;
+    gracePeriodInDays: BigNumber;
+}

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -4,6 +4,10 @@ import { Assertions } from "src/invariants";
 import { BigNumber } from "utils/bignumber";
 import * as singleLineString from "single-line-string";
 
+const MAX_COLLATERAL_TOKEN_INDEX_HEX = TermsContractParameters.generateHexValueOfLength(39);
+const MAX_COLLATERAL_AMOUNT_HEX = TermsContractParameters.generateHexValueOfLength(62);
+const MAX_GRACE_PERIOD_IN_DAYS_HEX = TermsContractParameters.generateHexValueOfLength(64);
+
 export interface CollateralizedTermsContractParameters {
     collateralTokenIndex: BigNumber;
     collateralAmount: BigNumber;

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -11,6 +11,10 @@ export interface CollateralizedTermsContractParameters {
 }
 
 export namespace TermsContractParameters {
+    export function generateHexValueOfLength(length: number): string {
+        return "0x" + "f".repeat(length);
+    }
+
     export function bitShiftLeft(target: BigNumber, numPlaces: number): BigNumber {
         const binaryTargetString = target.toString(2);
         const binaryTargetStringShifted = binaryTargetString + "0".repeat(numPlaces);

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -1,19 +1,40 @@
 import * as Web3 from "web3";
+import * as singleLineString from "single-line-string";
+import * as omit from "lodash.omit";
+
+import { BigNumber } from "utils/bignumber";
+
 import { ContractsAPI } from "src/apis";
 import { Assertions } from "src/invariants";
-import { BigNumber } from "utils/bignumber";
-import * as singleLineString from "single-line-string";
+import { DebtOrder, DebtRegistryEntry } from "src/types";
+
 import { TermsContractParameters } from "./terms_contract_parameters";
+import {
+    SimpleInterestLoanTerms,
+    SimpleInterestLoanOrder,
+    SimpleInterestTermsContractParameters,
+} from "./simple_interest_loan_adapter";
 
 const MAX_COLLATERAL_TOKEN_INDEX_HEX = TermsContractParameters.generateHexValueOfLength(2);
 const MAX_COLLATERAL_AMOUNT_HEX = TermsContractParameters.generateHexValueOfLength(23);
 const MAX_GRACE_PERIOD_IN_DAYS_HEX = TermsContractParameters.generateHexValueOfLength(2);
+
+// Extend order to include parameters necessary for a collateralized terms contract.
+export interface CollateralizedSimpleInterestLoanOrder extends SimpleInterestLoanOrder {
+    collateralTokenSymbol: string;
+    collateralAmount: BigNumber;
+    gracePeriodInDays: BigNumber;
+}
 
 export interface CollateralizedTermsContractParameters {
     collateralTokenIndex: BigNumber;
     collateralAmount: BigNumber;
     gracePeriodInDays: BigNumber;
 }
+
+interface CollateralizedSimpleInterestTermsContractParameters
+    extends SimpleInterestTermsContractParameters,
+        CollateralizedTermsContractParameters {}
 
 export const CollateralizedAdapterErrors = {
     INVALID_TOKEN_INDEX: (tokenIndex: BigNumber) =>
@@ -26,13 +47,21 @@ export const CollateralizedAdapterErrors = {
     GRACE_PERIOD_EXCEEDS_MAXIMUM: () =>
         singleLineString`The grace period exceeds the maximum value of 2^8 - 1`,
     INVALID_DECIMAL_VALUE: () => singleLineString`Values cannot be expressed as decimals.`,
+    MISMATCHED_TOKEN_SYMBOL: (tokenAddress: string, symbol: string) =>
+        singleLineString`Terms contract parameters are invalid for the given debt order.
+                         Token at address ${tokenAddress} does not
+                         correspond to specified token with symbol ${symbol}`,
+    MISMATCHED_TERMS_CONTRACT: (termsContractAddress: string) =>
+        singleLineString`Terms contract at address ${termsContractAddress} is not
+                         a CollateralizedSimpleInterestTermsContract.  As such, this adapter will
+                         not interface with the terms contract as expected`,
 };
 
 export class CollateralizedLoanTerms {
     private assert: Assertions;
 
-    constructor(web3: Web3, contracts: ContractsAPI) {
-        this.assert = new Assertions(web3, contracts);
+    constructor(web3: Web3, contractsAPI: ContractsAPI) {
+        this.assert = new Assertions(web3, contractsAPI);
     }
 
     public packParameters(params: CollateralizedTermsContractParameters): string {
@@ -110,6 +139,193 @@ export class CollateralizedLoanTerms {
         // Grace period has a maximum value that cannot be exceeded due to how we pack params.
         if (gracePeriodInDays.gt(MAX_GRACE_PERIOD_IN_DAYS_HEX)) {
             throw new Error(CollateralizedAdapterErrors.GRACE_PERIOD_EXCEEDS_MAXIMUM());
+        }
+    }
+}
+
+export class CollateralizedSimpleInterestLoanAdapter {
+    private assert: Assertions;
+    private contractsAPI: ContractsAPI;
+    private simpleInterestLoanTerms: SimpleInterestLoanTerms;
+    private collateralizedLoanTerms: CollateralizedLoanTerms;
+
+    public constructor(web3: Web3, contractsAPI: ContractsAPI) {
+        this.assert = new Assertions(web3, contractsAPI);
+        this.contractsAPI = contractsAPI;
+        this.simpleInterestLoanTerms = new SimpleInterestLoanTerms(web3, contractsAPI);
+        this.collateralizedLoanTerms = new CollateralizedLoanTerms(web3, contractsAPI);
+    }
+
+    public async toDebtOrder(
+        collateralizedSimpleInterestLoanOrder: CollateralizedSimpleInterestLoanOrder,
+    ): Promise<DebtOrder.Instance> {
+        this.assert.schema.collateralizedSimpleInterestLoanOrder(
+            "collateralizedSimpleInterestLoanOrder",
+            collateralizedSimpleInterestLoanOrder,
+        );
+
+        const {
+            // destructure simple interest loan order params.
+            principalTokenSymbol,
+            principalAmount,
+            interestRate,
+            amortizationUnit,
+            termLength,
+            // destructure collateralized loan order params.
+            collateralTokenSymbol,
+            collateralAmount,
+            gracePeriodInDays,
+        } = collateralizedSimpleInterestLoanOrder;
+
+        const principalToken = await this.contractsAPI.loadTokenBySymbolAsync(principalTokenSymbol);
+
+        const principalTokenIndex = await this.contractsAPI.getTokenIndexBySymbolAsync(
+            principalTokenSymbol,
+        );
+
+        const collateralTokenIndex = await this.contractsAPI.getTokenIndexBySymbolAsync(
+            collateralTokenSymbol,
+        );
+
+        const collateralizedSimpleInterestTermsContract = await this.contractsAPI.loadCollateralizedSimpleInterestTermsContract();
+
+        let debtOrder: DebtOrder.Instance = omit(collateralizedSimpleInterestLoanOrder, [
+            // omit the simple interest parameters that will be packed into the `termsContractParameters`.
+            "principalTokenSymbol",
+            "interestRate",
+            "amortizationUnit",
+            "termLength",
+            // omit the collateralized parameters that will be packed into the `termsContractParameters`.
+            "collateralTokenSymbol",
+            "collateralAmount",
+            "gracePeriodInDays",
+        ]);
+
+        const packedSimpleInterestParams = this.simpleInterestLoanTerms.packParameters({
+            principalTokenIndex,
+            principalAmount,
+            interestRate,
+            amortizationUnit,
+            termLength,
+        });
+
+        const packedCollateralizedParams = this.collateralizedLoanTerms.packParameters({
+            collateralTokenIndex,
+            collateralAmount,
+            gracePeriodInDays,
+        });
+
+        // Our final output is the perfect union of the packed simple interest params and the packed
+        // collateralized params.
+        const packedParams =
+            packedSimpleInterestParams.substr(0, 39) + packedCollateralizedParams.substr(39, 27);
+
+        debtOrder = {
+            ...debtOrder,
+            principalToken: principalToken.address,
+            termsContract: collateralizedSimpleInterestTermsContract.address,
+            termsContractParameters: packedParams,
+        };
+
+        return DebtOrder.applyNetworkDefaults(debtOrder, this.contractsAPI);
+    }
+
+    public async fromDebtOrder(
+        debtOrder: DebtOrder.Instance,
+    ): Promise<CollateralizedSimpleInterestLoanOrder> {
+        this.assert.schema.debtOrderWithTermsSpecified("debtOrder", debtOrder);
+
+        const { principalTokenIndex, collateralTokenIndex, ...params } = this.unpackParameters(
+            debtOrder.termsContractParameters,
+        );
+
+        const principalTokenSymbol = await this.contractsAPI.getTokenSymbolByIndexAsync(
+            principalTokenIndex,
+        );
+
+        const collateralTokenSymbol = await this.contractsAPI.getTokenSymbolByIndexAsync(
+            collateralTokenIndex,
+        );
+
+        // Assert that the principal token corresponds to the symbol we've unpacked.
+        this.assertTokenCorrespondsToSymbol(debtOrder.principalToken, principalTokenSymbol);
+
+        return {
+            ...debtOrder,
+            principalTokenSymbol,
+            collateralTokenSymbol,
+            ...params,
+        };
+    }
+
+    public async fromDebtRegistryEntry(
+        entry: DebtRegistryEntry,
+    ): Promise<CollateralizedSimpleInterestLoanOrder> {
+        await this.assertIsCollateralizedSimpleInterestTermsContract(entry.termsContract);
+
+        const { principalTokenIndex, collateralTokenIndex, ...params } = this.unpackParameters(
+            entry.termsContractParameters,
+        );
+
+        const principalTokenSymbol = await this.contractsAPI.getTokenSymbolByIndexAsync(
+            principalTokenIndex,
+        );
+
+        const collateralTokenSymbol = await this.contractsAPI.getTokenSymbolByIndexAsync(
+            collateralTokenIndex,
+        );
+
+        const loanOrder: CollateralizedSimpleInterestLoanOrder = {
+            principalTokenSymbol,
+            collateralTokenSymbol,
+            ...params,
+        };
+
+        return loanOrder;
+    }
+
+    private unpackParameters(
+        termsContractParameters: string,
+    ): CollateralizedSimpleInterestTermsContractParameters {
+        const simpleInterestParams = this.simpleInterestLoanTerms.unpackParameters(
+            termsContractParameters,
+        );
+
+        const collateralizedParams = this.collateralizedLoanTerms.unpackParameters(
+            termsContractParameters,
+        );
+
+        return {
+            ...simpleInterestParams,
+            ...collateralizedParams,
+        };
+    }
+
+    private async assertTokenCorrespondsToSymbol(
+        tokenAddress: string,
+        symbol: string,
+    ): Promise<void> {
+        const doesTokenCorrespondToSymbol = await this.contractsAPI.doesTokenCorrespondToSymbol(
+            tokenAddress,
+            symbol,
+        );
+
+        if (!doesTokenCorrespondToSymbol) {
+            throw new Error(
+                CollateralizedAdapterErrors.MISMATCHED_TOKEN_SYMBOL(tokenAddress, symbol),
+            );
+        }
+    }
+
+    private async assertIsCollateralizedSimpleInterestTermsContract(
+        termsContractAddress: string,
+    ): Promise<void> {
+        const collateralizedSimpleInterestTermsContract = await this.contractsAPI.loadCollateralizedSimpleInterestTermsContract();
+
+        if (termsContractAddress !== collateralizedSimpleInterestTermsContract.address) {
+            throw new Error(
+                CollateralizedAdapterErrors.MISMATCHED_TERMS_CONTRACT(termsContractAddress),
+            );
         }
     }
 }

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -30,8 +30,9 @@ export const CollateralizedAdapterErrors = {
     INVALID_TOKEN_INDEX: (tokenIndex: BigNumber) =>
         singleLineString`Token Registry does not track a token at index
                          ${tokenIndex.toString()}.`,
-    INVALID_COLLATERAL_AMOUNT_VALUE: () =>
-        singleLineString`Collateral amount cannot be negative or greater than 2^92 - 1.`,
+    COLLATERAL_AMOUNT_IS_NEGATIVE: () => singleLineString`Collateral amount cannot be negative.`,
+    COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM: () =>
+        singleLineString`Collateral amount exceeds maximum value of 2^92 - 1.`,
     GRACE_PERIOD_IS_NEGATIVE: () => singleLineString`The grace period cannot be negative.`,
     GRACE_PERIOD_EXCEEDS_MAXIMUM: () =>
         singleLineString`The grace period exceeds the maximum value of 2^8 - 1`,
@@ -71,8 +72,12 @@ export class CollateralizedLoanTerms {
     }
 
     private assertCollateralAmountWithinBounds(collateralAmount: BigNumber) {
-        if (collateralAmount.lt(0) || collateralAmount.gt(MAX_COLLATERAL_AMOUNT_HEX)) {
-            throw new Error(CollateralizedAdapterErrors.INVALID_COLLATERAL_AMOUNT_VALUE());
+        if (collateralAmount.lt(0)) {
+            throw new Error(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
+        }
+
+        if (collateralAmount.gt(MAX_COLLATERAL_AMOUNT_HEX)) {
+            throw new Error(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM());
         }
     }
 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,3 +1,4 @@
 import { SimpleInterestLoanAdapter } from "./simple_interest_loan_adapter";
+import { CollateralizedSimpleInterestLoanAdapter } from "./collateralized_simple_interest_loan_adapter";
 
-export { SimpleInterestLoanAdapter };
+export { SimpleInterestLoanAdapter, CollateralizedSimpleInterestLoanAdapter };

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -86,8 +86,6 @@ export const SimpleInterestAdapterErrors = {
                          interface with the terms contract as expected`,
 };
 
-const TX_DEFAULTS = { from: NULL_ADDRESS, gas: 0 };
-
 export class SimpleInterestLoanTerms {
     private assert: Assertions;
 
@@ -270,9 +268,7 @@ export class SimpleInterestLoanAdapter {
             principalTokenSymbol,
         );
 
-        const simpleInterestTermsContract = await this.contracts.loadSimpleInterestTermsContract(
-            TX_DEFAULTS,
-        );
+        const simpleInterestTermsContract = await this.contracts.loadSimpleInterestTermsContract();
 
         let debtOrder: DebtOrder.Instance = omit(simpleInterestLoanOrder, [
             "principalTokenSymbol",
@@ -384,10 +380,12 @@ export class SimpleInterestLoanAdapter {
         principalToken: string,
         symbol: string,
     ): Promise<void> {
-        const addressMappedToSymbol = await this.contracts.getTokenAddressBySymbolAsync(symbol);
+        const doesTokenCorrespondToSymbol = await this.contracts.doesTokenCorrespondToSymbol(
+            principalToken,
+            symbol,
+        );
 
-        // Validate that the
-        if (principalToken !== addressMappedToSymbol) {
+        if (!doesTokenCorrespondToSymbol) {
             throw new Error(
                 SimpleInterestAdapterErrors.MISMATCHED_TOKEN_SYMBOL(principalToken, symbol),
             );

--- a/src/adapters/terms_contract_parameters.ts
+++ b/src/adapters/terms_contract_parameters.ts
@@ -1,0 +1,17 @@
+import { BigNumber } from "utils/bignumber";
+
+export namespace TermsContractParameters {
+    export function generateHexValueOfLength(length: number): string {
+        return "0x" + "f".repeat(length);
+    }
+
+    export function bitShiftLeft(target: BigNumber, numPlaces: number): BigNumber {
+        const binaryTargetString = target.toString(2);
+        const binaryTargetStringShifted = binaryTargetString + "0".repeat(numPlaces);
+        return new BigNumber(binaryTargetStringShifted, 2);
+    }
+
+    export function isDecimalValue(value: BigNumber): boolean {
+        return value.toNumber() % 1 != 0;
+    }
+}

--- a/src/apis/contracts_api.ts
+++ b/src/apis/contracts_api.ts
@@ -44,9 +44,9 @@ export interface DharmaContracts {
 }
 
 export const ContractsError = {
-    SIMPLE_INTEREST_TERMS_CONTRACT_NOT_SUPPORTED: (principalToken: string) =>
+    SIMPLE_INTEREST_TERMS_CONTRACT_NOT_SUPPORTED: (tokenAddress: string) =>
         singleLineString`SimpleInterestTermsContract not supported for principal token at
-                address ${principalToken}`,
+                address ${tokenAddress}`,
     CANNOT_FIND_TOKEN_WITH_SYMBOL: (symbol: string) =>
         singleLineString`Could not find token associated with symbol ${symbol}.`,
     CANNOT_FIND_TOKEN_WITH_INDEX: (index: number) =>
@@ -276,7 +276,7 @@ export class ContractsAPI {
 
         const matchingTermsContract = _.find(
             supportedTermsContracts,
-            termsContract => termsContract.address === contractAddress,
+            (termsContract) => termsContract.address === contractAddress,
         );
 
         if (!matchingTermsContract) {
@@ -414,6 +414,14 @@ export class ContractsAPI {
         const tokenAddress = await this.getTokenAddressBySymbolAsync(symbol);
 
         return this.loadERC20TokenAsync(tokenAddress, transactionOptions);
+    }
+
+    public async doesTokenCorrespondToSymbol(
+        tokenAddress: string,
+        symbol: string,
+    ): Promise<boolean> {
+        const addressMappedToSymbol = await this.getTokenAddressBySymbolAsync(symbol);
+        return tokenAddress === addressMappedToSymbol;
     }
 
     private getERC20TokenCacheKey(tokenAddress: string): string {

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -11,10 +11,10 @@ import { TxData } from "../types";
 const TRANSFER_GAS_MAXIMUM = 70000;
 
 export const TokenAPIErrors = {
-    INSUFFICIENT_SENDER_BALANCE: address =>
+    INSUFFICIENT_SENDER_BALANCE: (address) =>
         singleLineString`SENDER with address ${address} does not have sufficient balance in the specified token
                          to execute this transfer.`,
-    INSUFFICIENT_SENDER_ALLOWANCE: address =>
+    INSUFFICIENT_SENDER_ALLOWANCE: (address) =>
         singleLineString`SENDER with address ${address} does not have sufficient allowance in the specified token
                          to execute this transfer.`,
 };

--- a/src/invariants/schema.ts
+++ b/src/invariants/schema.ts
@@ -43,6 +43,14 @@ export class SchemaAssertions {
         this.assertConformsToSchema(variableName, value, Schemas.simpleInterestLoanOrderSchema);
     }
 
+    public collateralizedSimpleInterestLoanOrder(variableName: string, value: any) {
+        this.assertConformsToSchema(
+            variableName,
+            value,
+            Schemas.collateralizedSimpleInterestLoanOrderSchema,
+        );
+    }
+
     public debtOrder(variableName: string, value: any) {
         this.assertConformsToSchema(variableName, value, Schemas.debtOrderSchema);
     }

--- a/src/schemas/collateralized_simple_interest_loan_order_schema.ts
+++ b/src/schemas/collateralized_simple_interest_loan_order_schema.ts
@@ -1,0 +1,13 @@
+export const collateralizedSimpleInterestLoanOrderSchema = {
+    id: "/CollateralizedSimpleInterestLoanOrder",
+    allOf: [
+        { $ref: "/SimpleInterestLoanOrder" },
+        {
+            properties: {
+                collateralAmount: { $ref: "/WholeNumber" },
+                gracePeriodInDays: { $ref: "/WholeNumber" },
+            },
+            required: ["collateralTokenSymbol", "collateralAmount", "gracePeriodInDays"],
+        },
+    ],
+};

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -11,6 +11,7 @@ import {
     debtOrderWithTermsDebtorAndCreditorSpecifiedSchema,
 } from "./debt_order_schemas";
 import { simpleInterestLoanOrderSchema } from "./simple_interest_parameters_schema";
+import { collateralizedSimpleInterestLoanOrderSchema } from "./collateralized_simple_interest_loan_order_schema";
 
 export const Schemas = {
     addressSchema,
@@ -21,5 +22,6 @@ export const Schemas = {
     debtOrderWithTermsAndDebtorSpecifiedSchema,
     debtOrderWithTermsDebtorAndCreditorSpecifiedSchema,
     simpleInterestLoanOrderSchema,
+    collateralizedSimpleInterestLoanOrderSchema,
     wholeNumberSchema,
 };

--- a/src/types/error_parser.ts
+++ b/src/types/error_parser.ts
@@ -36,8 +36,8 @@ export class ErrorParser {
             const origin = this.parseOrigin(entry);
             return _.chain(entry.events)
                 .map(this.parseErrorID) // pull out error ids
-                .filter(n => n != null) // filter out undefined values
-                .map(n => this.messageForErrorWithID(n, origin)) // pull human-readable messages for each error id
+                .filter((n) => n != null) // filter out undefined values
+                .map((n) => this.messageForErrorWithID(n, origin)) // pull human-readable messages for each error id
                 .value();
         } else {
             return [];


### PR DESCRIPTION
This PR introduces the following types:

- `CollateralizedLoanTerms`: responsible for packing and unpacking params
- `CollateralizedAdapterErrors`: represents the errors that can be thrown by the adapter
- `CollateralizedTermsContractParameters`: the interface defining the params

This PR does not include the actual adapter or a test suite. Those will following in future PRs.

This branch merges into the main feature branch: `collateralized-simple-interest-adapter`