### PR TITLE
Introduce `CollateralizedSimpleInterestLoanAdapter`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "main": "dist/dharma.umd.js",
     "module": "dist/lib/src/index.js",
     "typings": "dist/types/src/index.d.ts",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "author": "Nadav Hollander <nadav@dharma.io>",
     "repository": {
         "type": "git",
@@ -25,7 +23,8 @@
         "start": "rollup -c rollup.config.ts -w",
         "chain": "bash scripts/init_chain.sh",
         "test": "jest --runInBand",
-        "docs": "typedoc --theme markdown --mdHideSources --name dharma.js --excludePrivate --excludeExternals --excludeProtected --hideGenerator --target ES6 --out generated_docs/ src/apis",
+        "docs":
+            "typedoc --theme markdown --mdHideSources --name dharma.js --excludePrivate --excludeExternals --excludeProtected --hideGenerator --target ES6 --out generated_docs/ src/apis",
         "test:watch": "jest --watch --runInBand",
         "test:prod": "npm run lint && npm run test -- --coverage --no-cache --runInBand",
         "deploy-docs": "ts-node tools/gh-pages-publish",
@@ -37,10 +36,7 @@
         "commitmsg": "commitlint -e $GIT_PARAMS"
     },
     "lint-staged": {
-        "{src,__test__,__mocks__}/**/*.ts": [
-            "prettier --write",
-            "git add"
-        ]
+        "{src,__test__,__mocks__}/**/*.ts": ["prettier --write"]
     },
     "config": {
         "commitizen": {
@@ -48,7 +44,8 @@
         },
         "validate-commit-msg": {
             "types": "conventional-commit-types",
-            "helpMessage": "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
+            "helpMessage":
+                "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
         }
     },
     "jest": {
@@ -56,18 +53,9 @@
             ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
         },
         "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-        "moduleFileExtensions": [
-            "ts",
-            "tsx",
-            "js"
-        ],
-        "modulePaths": [
-            "<rootDir>/"
-        ],
-        "coveragePathIgnorePatterns": [
-            "/node_modules/",
-            "/test/"
-        ],
+        "moduleFileExtensions": ["ts", "tsx", "js"],
+        "modulePaths": ["<rootDir>/"],
+        "coveragePathIgnorePatterns": ["/node_modules/", "/test/"],
         "coverageThreshold": {
             "global": {
                 "branches": 40,

--- a/src/adapters/base_adapter.ts
+++ b/src/adapters/base_adapter.ts
@@ -1,6 +1,0 @@
-import { DebtOrder } from "../types";
-
-export abstract class BaseAdapter {
-    public abstract async generateAsync(params: object): Promise<DebtOrder.Instance>;
-    public abstract async validateAsync(debtOrder: DebtOrder.Instance): Promise<void>;
-}

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -66,6 +66,20 @@ export class CollateralizedLoanTerms {
         return `0x${baseTenParameters.toString(16).padStart(64, "0")}`;
     }
 
+    public unpackParameters(packedParams: string): CollateralizedTermsContractParameters {
+        this.assert.schema.bytes32("packedParams", packedParams);
+
+        const collateralTokenIndexHex = `0x${packedParams.substr(39, 2)}`;
+        const collateralAmountHex = `0x${packedParams.substr(41, 23)}`;
+        const gracePeriodInDaysHex = `0x${packedParams.substr(64, 2)}`;
+
+        return {
+            collateralTokenIndex: new BigNumber(collateralTokenIndexHex),
+            collateralAmount: new BigNumber(collateralAmountHex),
+            gracePeriodInDays: new BigNumber(gracePeriodInDaysHex),
+        };
+    }
+
     private assertCollateralTokenIndexWithinBounds(collateralTokenIndex: BigNumber) {
         if (collateralTokenIndex.lt(0) || collateralTokenIndex.gt(MAX_COLLATERAL_TOKEN_INDEX_HEX)) {
             throw new Error(CollateralizedAdapterErrors.INVALID_TOKEN_INDEX(collateralTokenIndex));

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -4,11 +4,18 @@ import { Assertions } from "src/invariants";
 import { BigNumber } from "utils/bignumber";
 import * as singleLineString from "single-line-string";
 import { TermsContractParameters } from "./terms_contract_parameters";
-import { SimpleInterestLoanTerms } from "./simple_interest_loan_adapter";
+import { SimpleInterestLoanTerms, SimpleInterestLoanOrder } from "./simple_interest_loan_adapter";
 
 const MAX_COLLATERAL_TOKEN_INDEX_HEX = TermsContractParameters.generateHexValueOfLength(2);
 const MAX_COLLATERAL_AMOUNT_HEX = TermsContractParameters.generateHexValueOfLength(23);
 const MAX_GRACE_PERIOD_IN_DAYS_HEX = TermsContractParameters.generateHexValueOfLength(2);
+
+// Extend order to include parameters necessary for a collateralized terms contract.
+export interface CollateralizedSimpleInterestLoanOrder extends SimpleInterestLoanOrder {
+    collateralTokenSymbol: string;
+    collateralAmount: BigNumber;
+    gracePeriodInDays: BigNumber;
+}
 
 export interface CollateralizedTermsContractParameters {
     collateralTokenIndex: BigNumber;

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -4,9 +4,9 @@ import { Assertions } from "src/invariants";
 import { BigNumber } from "utils/bignumber";
 import * as singleLineString from "single-line-string";
 
-const MAX_COLLATERAL_TOKEN_INDEX_HEX = TermsContractParameters.generateHexValueOfLength(39);
-const MAX_COLLATERAL_AMOUNT_HEX = TermsContractParameters.generateHexValueOfLength(62);
-const MAX_GRACE_PERIOD_IN_DAYS_HEX = TermsContractParameters.generateHexValueOfLength(64);
+const MAX_COLLATERAL_TOKEN_INDEX_HEX = TermsContractParameters.generateHexValueOfLength(2);
+const MAX_COLLATERAL_AMOUNT_HEX = TermsContractParameters.generateHexValueOfLength(23);
+const MAX_GRACE_PERIOD_IN_DAYS_HEX = TermsContractParameters.generateHexValueOfLength(2);
 
 export interface CollateralizedTermsContractParameters {
     collateralTokenIndex: BigNumber;

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -179,8 +179,7 @@ export class CollateralizedSimpleInterestLoanAdapter {
             collateralTokenSymbol,
         );
 
-        // TODO(kayvon): this needs to be the collateralized simple interest contract
-        const simpleInterestTermsContract = await this.contractsAPI.loadSimpleInterestTermsContract();
+        const collateralizedSimpleInterestTermsContract = await this.contractsAPI.loadCollateralizedSimpleInterestTermsContract();
 
         let debtOrder: DebtOrder.Instance = omit(collateralizedSimpleInterestLoanOrder, [
             // omit the simple interest parameters that will be packed into the `termsContractParameters`.
@@ -216,7 +215,7 @@ export class CollateralizedSimpleInterestLoanAdapter {
         debtOrder = {
             ...debtOrder,
             principalToken: principalToken.address,
-            termsContract: simpleInterestTermsContract.address,
+            termsContract: collateralizedSimpleInterestTermsContract.address,
             termsContractParameters: packedParams,
         };
 
@@ -337,10 +336,9 @@ export class CollateralizedSimpleInterestLoanAdapter {
     private async assertIsCollateralizedSimpleInterestTermsContract(
         termsContractAddress: string,
     ): Promise<void> {
-        // TODO(kayvon): this should query the contracts API for the collateralized simple interest terms contract.
-        const simpleInterestTermsContract = await this.contractsAPI.loadSimpleInterestTermsContract();
+        const collateralizedSimpleInterestTermsContract = await this.contractsAPI.loadCollateralizedSimpleInterestTermsContract();
 
-        if (termsContractAddress !== simpleInterestTermsContract.address) {
+        if (termsContractAddress !== collateralizedSimpleInterestTermsContract.address) {
             throw new Error(
                 CollateralizedAdapterErrors.MISMATCHED_TERMS_CONTRACT(termsContractAddress),
             );

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -3,6 +3,7 @@ import { ContractsAPI } from "src/apis";
 import { Assertions } from "src/invariants";
 import { BigNumber } from "utils/bignumber";
 import * as singleLineString from "single-line-string";
+import { TermsContractParameters } from "./terms_contract_parameters";
 
 const MAX_COLLATERAL_TOKEN_INDEX_HEX = TermsContractParameters.generateHexValueOfLength(2);
 const MAX_COLLATERAL_AMOUNT_HEX = TermsContractParameters.generateHexValueOfLength(23);
@@ -12,18 +13,6 @@ export interface CollateralizedTermsContractParameters {
     collateralTokenIndex: BigNumber;
     collateralAmount: BigNumber;
     gracePeriodInDays: BigNumber;
-}
-
-export namespace TermsContractParameters {
-    export function generateHexValueOfLength(length: number): string {
-        return "0x" + "f".repeat(length);
-    }
-
-    export function bitShiftLeft(target: BigNumber, numPlaces: number): BigNumber {
-        const binaryTargetString = target.toString(2);
-        const binaryTargetStringShifted = binaryTargetString + "0".repeat(numPlaces);
-        return new BigNumber(binaryTargetStringShifted, 2);
-    }
 }
 
 export const CollateralizedAdapterErrors = {

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -72,7 +72,7 @@ export class CollateralizedLoanTerms {
 
     private assertCollateralTokenIndexWithinBounds(collateralTokenIndex: BigNumber) {
         // Collateral token index cannot be a decimal value.
-        if (this.isDecimalValue(collateralTokenIndex)) {
+        if (TermsContractParameters.isDecimalValue(collateralTokenIndex)) {
             throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
         }
 
@@ -83,7 +83,7 @@ export class CollateralizedLoanTerms {
 
     private assertCollateralAmountWithinBounds(collateralAmount: BigNumber) {
         // Collateral amount cannot be a decimal value.
-        if (this.isDecimalValue(collateralAmount)) {
+        if (TermsContractParameters.isDecimalValue(collateralAmount)) {
             throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
         }
 
@@ -96,14 +96,9 @@ export class CollateralizedLoanTerms {
         }
     }
 
-    private isDecimalValue(value: BigNumber): boolean {
-        const [, rightOfDecimal] = value.toString().split(".");
-        return rightOfDecimal.length > 0;
-    }
-
     private assertGracePeriodInDaysWithinBounds(gracePeriodInDays: BigNumber) {
         // Grace period cannot be a decimal value.
-        if (this.isDecimalValue(gracePeriodInDays)) {
+        if (TermsContractParameters.isDecimalValue(gracePeriodInDays)) {
             throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
         }
 

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -4,6 +4,7 @@ import { Assertions } from "src/invariants";
 import { BigNumber } from "utils/bignumber";
 import * as singleLineString from "single-line-string";
 import { TermsContractParameters } from "./terms_contract_parameters";
+import { SimpleInterestLoanTerms } from "./simple_interest_loan_adapter";
 
 const MAX_COLLATERAL_TOKEN_INDEX_HEX = TermsContractParameters.generateHexValueOfLength(2);
 const MAX_COLLATERAL_AMOUNT_HEX = TermsContractParameters.generateHexValueOfLength(23);
@@ -31,8 +32,8 @@ export const CollateralizedAdapterErrors = {
 export class CollateralizedLoanTerms {
     private assert: Assertions;
 
-    constructor(web3: Web3, contracts: ContractsAPI) {
-        this.assert = new Assertions(web3, contracts);
+    constructor(web3: Web3, contractsAPI: ContractsAPI) {
+        this.assert = new Assertions(web3, contractsAPI);
     }
 
     public packParameters(params: CollateralizedTermsContractParameters): string {
@@ -111,5 +112,19 @@ export class CollateralizedLoanTerms {
         if (gracePeriodInDays.gt(MAX_GRACE_PERIOD_IN_DAYS_HEX)) {
             throw new Error(CollateralizedAdapterErrors.GRACE_PERIOD_EXCEEDS_MAXIMUM());
         }
+    }
+}
+
+export class CollateralizedSimpleInterestLoanAdapter {
+    private assert: Assertions;
+    private contractsAPI: ContractsAPI;
+    private simpleInterestLoanTerms: SimpleInterestLoanTerms;
+    private collateralizedLoanTerms: CollateralizedLoanTerms;
+
+    public constructor(web3: Web3, contractsAPI: ContractsAPI) {
+        this.assert = new Assertions(web3, contractsAPI);
+        this.contractsAPI = contractsAPI;
+        this.simpleInterestLoanTerms = new SimpleInterestLoanTerms(web3, contractsAPI);
+        this.collateralizedLoanTerms = new CollateralizedLoanTerms(web3, contractsAPI);
     }
 }

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -25,6 +25,7 @@ export const CollateralizedAdapterErrors = {
     GRACE_PERIOD_IS_NEGATIVE: () => singleLineString`The grace period cannot be negative.`,
     GRACE_PERIOD_EXCEEDS_MAXIMUM: () =>
         singleLineString`The grace period exceeds the maximum value of 2^8 - 1`,
+    INVALID_DECIMAL_VALUE: () => singleLineString`Values cannot be expressed as decimals.`,
 };
 
 export class CollateralizedLoanTerms {
@@ -70,12 +71,22 @@ export class CollateralizedLoanTerms {
     }
 
     private assertCollateralTokenIndexWithinBounds(collateralTokenIndex: BigNumber) {
+        // Collateral token index cannot be a decimal value.
+        if (this.isDecimalValue(collateralTokenIndex)) {
+            throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+        }
+
         if (collateralTokenIndex.lt(0) || collateralTokenIndex.gt(MAX_COLLATERAL_TOKEN_INDEX_HEX)) {
             throw new Error(CollateralizedAdapterErrors.INVALID_TOKEN_INDEX(collateralTokenIndex));
         }
     }
 
     private assertCollateralAmountWithinBounds(collateralAmount: BigNumber) {
+        // Collateral amount cannot be a decimal value.
+        if (this.isDecimalValue(collateralAmount)) {
+            throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+        }
+
         if (collateralAmount.lt(0)) {
             throw new Error(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
         }
@@ -85,7 +96,17 @@ export class CollateralizedLoanTerms {
         }
     }
 
+    private isDecimalValue(value: BigNumber): boolean {
+        const [, rightOfDecimal] = value.toString().split(".");
+        return rightOfDecimal.length > 0;
+    }
+
     private assertGracePeriodInDaysWithinBounds(gracePeriodInDays: BigNumber) {
+        // Grace period cannot be a decimal value.
+        if (this.isDecimalValue(gracePeriodInDays)) {
+            throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+        }
+
         // Grace period can't be negative.
         if (gracePeriodInDays.lt(0)) {
             throw new Error(CollateralizedAdapterErrors.GRACE_PERIOD_IS_NEGATIVE());

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -143,6 +143,11 @@ export class CollateralizedSimpleInterestLoanAdapter {
     public async toDebtOrder(
         collateralizedSimpleInterestLoanOrder: CollateralizedSimpleInterestLoanOrder,
     ): Promise<DebtOrder.Instance> {
+        this.assert.schema.collateralizedSimpleInterestLoanOrder(
+            "collateralizedSimpleInterestLoanOrder",
+            collateralizedSimpleInterestLoanOrder,
+        );
+
         const {
             // destructure simple interest loan order params.
             principalTokenSymbol,

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -86,8 +86,6 @@ export const SimpleInterestAdapterErrors = {
                          interface with the terms contract as expected`,
 };
 
-const TX_DEFAULTS = { from: NULL_ADDRESS, gas: 0 };
-
 export class SimpleInterestLoanTerms {
     private assert: Assertions;
 
@@ -270,9 +268,7 @@ export class SimpleInterestLoanAdapter {
             principalTokenSymbol,
         );
 
-        const simpleInterestTermsContract = await this.contracts.loadSimpleInterestTermsContract(
-            TX_DEFAULTS,
-        );
+        const simpleInterestTermsContract = await this.contracts.loadSimpleInterestTermsContract();
 
         let debtOrder: DebtOrder.Instance = omit(simpleInterestLoanOrder, [
             "principalTokenSymbol",

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -380,10 +380,12 @@ export class SimpleInterestLoanAdapter {
         principalToken: string,
         symbol: string,
     ): Promise<void> {
-        const addressMappedToSymbol = await this.contracts.getTokenAddressBySymbolAsync(symbol);
+        const doesTokenCorrespondToSymbol = await this.contracts.doesTokenCorrespondToSymbol(
+            principalToken,
+            symbol,
+        );
 
-        // Validate that the
-        if (principalToken !== addressMappedToSymbol) {
+        if (!doesTokenCorrespondToSymbol) {
             throw new Error(
                 SimpleInterestAdapterErrors.MISMATCHED_TOKEN_SYMBOL(principalToken, symbol),
             );

--- a/src/adapters/terms_contract_parameters.ts
+++ b/src/adapters/terms_contract_parameters.ts
@@ -1,0 +1,13 @@
+import { BigNumber } from "utils/bignumber";
+
+export namespace TermsContractParameters {
+    export function generateHexValueOfLength(length: number): string {
+        return "0x" + "f".repeat(length);
+    }
+
+    export function bitShiftLeft(target: BigNumber, numPlaces: number): BigNumber {
+        const binaryTargetString = target.toString(2);
+        const binaryTargetStringShifted = binaryTargetString + "0".repeat(numPlaces);
+        return new BigNumber(binaryTargetStringShifted, 2);
+    }
+}

--- a/src/adapters/terms_contract_parameters.ts
+++ b/src/adapters/terms_contract_parameters.ts
@@ -12,7 +12,6 @@ export namespace TermsContractParameters {
     }
 
     export function isDecimalValue(value: BigNumber): boolean {
-        const [, rightOfDecimal] = value.toString().split(".");
-        return rightOfDecimal.length > 0;
+        return value.toNumber() % 1 != 0;
     }
 }

--- a/src/adapters/terms_contract_parameters.ts
+++ b/src/adapters/terms_contract_parameters.ts
@@ -10,4 +10,9 @@ export namespace TermsContractParameters {
         const binaryTargetStringShifted = binaryTargetString + "0".repeat(numPlaces);
         return new BigNumber(binaryTargetStringShifted, 2);
     }
+
+    export function isDecimalValue(value: BigNumber): boolean {
+        const [, rightOfDecimal] = value.toString().split(".");
+        return rightOfDecimal.length > 0;
+    }
 }

--- a/src/apis/contracts_api.ts
+++ b/src/apis/contracts_api.ts
@@ -44,9 +44,9 @@ export interface DharmaContracts {
 }
 
 export const ContractsError = {
-    SIMPLE_INTEREST_TERMS_CONTRACT_NOT_SUPPORTED: (principalToken: string) =>
+    SIMPLE_INTEREST_TERMS_CONTRACT_NOT_SUPPORTED: (tokenAddress: string) =>
         singleLineString`SimpleInterestTermsContract not supported for principal token at
-                address ${principalToken}`,
+                address ${tokenAddress}`,
     CANNOT_FIND_TOKEN_WITH_SYMBOL: (symbol: string) =>
         singleLineString`Could not find token associated with symbol ${symbol}.`,
     CANNOT_FIND_TOKEN_WITH_INDEX: (index: number) =>
@@ -417,11 +417,11 @@ export class ContractsAPI {
     }
 
     public async doesTokenCorrespondToSymbol(
-        principalToken: string,
+        tokenAddress: string,
         symbol: string,
     ): Promise<boolean> {
         const addressMappedToSymbol = await this.getTokenAddressBySymbolAsync(symbol);
-        return principalToken === addressMappedToSymbol;
+        return tokenAddress === addressMappedToSymbol;
     }
 
     private getERC20TokenCacheKey(tokenAddress: string): string {

--- a/src/apis/contracts_api.ts
+++ b/src/apis/contracts_api.ts
@@ -383,6 +383,14 @@ export class ContractsAPI {
         return this.loadERC20TokenAsync(tokenAddress, transactionOptions);
     }
 
+    public async doesTokenCorrespondToSymbol(
+        principalToken: string,
+        symbol: string,
+    ): Promise<boolean> {
+        const addressMappedToSymbol = await this.getTokenAddressBySymbolAsync(symbol);
+        return principalToken === addressMappedToSymbol;
+    }
+
     private getERC20TokenCacheKey(tokenAddress: string): string {
         return `ERC20_${tokenAddress}`;
     }

--- a/src/invariants/schema.ts
+++ b/src/invariants/schema.ts
@@ -43,6 +43,14 @@ export class SchemaAssertions {
         this.assertConformsToSchema(variableName, value, Schemas.simpleInterestLoanOrderSchema);
     }
 
+    public collateralizedSimpleInterestLoanOrder(variableName: string, value: any) {
+        this.assertConformsToSchema(
+            variableName,
+            value,
+            Schemas.collateralizedSimpleInterestLoanOrderSchema,
+        );
+    }
+
     public debtOrder(variableName: string, value: any) {
         this.assertConformsToSchema(variableName, value, Schemas.debtOrderSchema);
     }

--- a/src/schemas/collateralized_simple_interest_loan_order_schema.ts
+++ b/src/schemas/collateralized_simple_interest_loan_order_schema.ts
@@ -1,0 +1,13 @@
+export const collateralizedSimpleInterestLoanOrderSchema = {
+    id: "/CollateralizedSimpleInterestLoanOrder",
+    allOf: [
+        { $ref: "/SimpleInterestLoanOrder" },
+        {
+            properties: {
+                collateralAmount: { $ref: "/WholeNumber" },
+                gracePeriodInDays: { $ref: "/WholeNumber" },
+            },
+            required: ["collateralTokenSymbol", "collateralAmount", "gracePeriodInDays"],
+        },
+    ],
+};

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -11,6 +11,7 @@ import {
     debtOrderWithTermsDebtorAndCreditorSpecifiedSchema,
 } from "./debt_order_schemas";
 import { simpleInterestLoanOrderSchema } from "./simple_interest_parameters_schema";
+import { collateralizedSimpleInterestLoanOrderSchema } from "./collateralized_simple_interest_loan_order_schema";
 
 export const Schemas = {
     addressSchema,
@@ -21,5 +22,6 @@ export const Schemas = {
     debtOrderWithTermsAndDebtorSpecifiedSchema,
     debtOrderWithTermsDebtorAndCreditorSpecifiedSchema,
     simpleInterestLoanOrderSchema,
+    collateralizedSimpleInterestLoanOrderSchema,
     wholeNumberSchema,
 };


### PR DESCRIPTION
This PR introduces the `CollateralizedSimpleInterestLoanAdapter` class, which houses three public methods:

```
public async toDebtOrder(
        collateralizedSimpleInterestLoanOrder: CollateralizedSimpleInterestLoanOrder,
    ): Promise<DebtOrder.Instance>;

public async fromDebtOrder(
        debtOrder: DebtOrder.Instance,
    ): Promise<CollateralizedSimpleInterestLoanOrder>;

public async fromDebtRegistryEntry(
        entry: DebtRegistryEntry,
    ): Promise<CollateralizedSimpleInterestLoanOrder>;
```

This PR is blocked by the need for the contracts API to have a method that can return the address of the collateralized simple interest terms contract.