### PR TITLE
build: import from forked abi-decoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "dependencies": {
         "@dharmaprotocol/contracts": "0.0.26",
         "@types/lodash": "^4.14.104",
-        "abi-decoder": "^1.1.0",
+        "abi-decoder": "https://github.com/dharmaprotocol/abi-decoder",
         "bignumber.js": "^5.0.0",
         "ethereumjs-util": "^5.1.4",
         "jsonschema": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,7 +322,7 @@ abbrev@1:
 
 "abi-decoder@https://github.com/dharmaprotocol/abi-decoder":
   version "1.1.0"
-  resolved "https://github.com/dharmaprotocol/abi-decoder#c48f6200d6535bd66395d1318d7e756b23cdd11f"
+  resolved "https://github.com/dharmaprotocol/abi-decoder#9448e51a134633673ccbb07a3df0ed2b0c47ab62"
   dependencies:
     babel-core "^6.23.1"
     babel-loader "^6.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,9 +306,9 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-"NonFungibleToken@git+https://github.com/dharmaprotocol/NonFungibleToken.git":
+"NonFungibleToken@https://github.com/dharmaprotocol/NonFungibleToken.git":
   version "0.0.1"
-  resolved "git+https://github.com/dharmaprotocol/NonFungibleToken.git#3a45b200d14be1e1fc454f4b0fbf7f7b0d81f133"
+  resolved "https://github.com/dharmaprotocol/NonFungibleToken.git#3a45b200d14be1e1fc454f4b0fbf7f7b0d81f133"
   dependencies:
     zeppelin-solidity "^1.4.0"
 
@@ -320,9 +320,9 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-abi-decoder@^1.1.0:
+"abi-decoder@https://github.com/dharmaprotocol/abi-decoder":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abi-decoder/-/abi-decoder-1.1.0.tgz#07f063e2a8f0ca1750fe4cd0dd112f6103ce3455"
+  resolved "https://github.com/dharmaprotocol/abi-decoder#c48f6200d6535bd66395d1318d7e756b23cdd11f"
   dependencies:
     babel-core "^6.23.1"
     babel-loader "^6.3.2"


### PR DESCRIPTION
This PR introduces the following changes:

- Import abi-decoder from our forked version of the repository (linked [here](https://github.com/dharmaprotocol/abi-decoder))

Motivation:

Consensys' abi-decoder has a distribution version that is compiled down to ES5 in their repo, but their package.json file does not point to it as the main entry point.  This creates issues for any projects that may be trying to minify abi-decoder (and in turn, our library, given that we inherit from abi-decoder), given that many minifiers throw on non-ES5 javascript.   Our forked version resolves this issue.