### PR TITLE
fix: relative paths imports for utils

### DIFF
--- a/src/apis/contracts_api.ts
+++ b/src/apis/contracts_api.ts
@@ -29,7 +29,7 @@ import {
     TOKEN_TRANSFER_PROXY_CONTRACT_CACHE_KEY,
     NULL_ADDRESS,
     COLLATERALIZED_SIMPLE_INTEREST_TERMS_CONTRACT_CACHE_KEY,
-} from "utils/constants";
+} from "../../utils/constants";
 import * as singleLineString from "single-line-string";
 
 // types

--- a/src/wrappers/contract_wrappers/collateralized_simple_interest_terms_contract_wrapper.ts
+++ b/src/wrappers/contract_wrappers/collateralized_simple_interest_terms_contract_wrapper.ts
@@ -5,8 +5,8 @@
 // tslint:disable-next-line:no-unused-variable
 import { TxData, TxDataPayable } from "../../types";
 import * as promisify from "tiny-promisify";
-import { classUtils } from "utils/class_utils";
-import { Web3Utils } from "utils/web3_utils";
+import { classUtils } from "../../../utils/class_utils";
+import { Web3Utils } from "../../../utils/web3_utils";
 import { BigNumber } from "bignumber.js";
 import { CollateralizedSimpleInterestTermsContract as ContractArtifacts } from "@dharmaprotocol/contracts";
 import * as Web3 from "web3";


### PR DESCRIPTION
This PR introduces the following changes:

- re-introduces relative paths for imports from "utils".  For reasons that are currently unknown, our build command is breaking on these relative paths.  In the interest of time and several things blocked on this, I vote we stick with relative paths in the short term.