### PR TITLE
Add `generate` method to the order API

### DIFF
--- a/__test__/integration/order_api/order_api.spec.ts
+++ b/__test__/integration/order_api/order_api.spec.ts
@@ -1,7 +1,14 @@
-import { OrderAPI } from "src/apis/order_api";
-import { ContractsAPI } from "src/apis/contracts_api";
+// External
+import * as Web3 from "web3";
+
+// APIs
+import { AdaptersAPI, ContractsAPI, OrderAPI, SignerAPI } from "src/apis";
+
+// Utils
 import { Web3Utils } from "utils/web3_utils";
-import { SignerAPI } from "src/apis/signer_api";
+import { ACCOUNTS } from "../../accounts";
+
+// Scenarios
 import {
     VALID_ORDERS,
     INVALID_ORDERS,
@@ -10,10 +17,14 @@ import {
     INVALID_ORDER_CANCELLATIONS,
     INVALID_ISSUANCE_CANCELLATIONS,
     NONCONSENUAL_ORDERS,
+    SUCCESSFUL_ORDER_GENERATION,
+    UNSUCCESSFUL_ORDER_GENERATION,
 } from "./scenarios";
-import { OrderScenarioRunner } from "./order_scenario_runner";
-import * as Web3 from "web3";
 
+// Runners
+import { OrderScenarioRunner } from "./order_scenario_runner";
+
+// Wrappers
 import {
     DummyTokenContract,
     TokenRegistryContract,
@@ -22,8 +33,6 @@ import {
     SimpleInterestTermsContractContract,
     TokenTransferProxyContract,
 } from "src/wrappers";
-
-import { ACCOUNTS } from "../../accounts";
 
 // Given that this is an integration test, we unmock the Dharma
 // smart contracts artifacts package to pull the most recently
@@ -48,6 +57,7 @@ describe("Order API (Integration Tests)", () => {
         scenarioRunner.web3Utils = new Web3Utils(web3);
         scenarioRunner.orderApi = new OrderAPI(web3, contractsApi);
         scenarioRunner.orderSigner = new SignerAPI(web3, contractsApi);
+        scenarioRunner.adaptersApi = new AdaptersAPI(web3, contractsApi);
         scenarioRunner.principalToken = await DummyTokenContract.at(
             principalTokenAddress,
             web3,
@@ -101,6 +111,16 @@ describe("Order API (Integration Tests)", () => {
 
         describe("Valid order cancellations", () => {
             VALID_ISSUANCE_CANCELLATIONS.forEach(scenarioRunner.testIssuanceCancelScenario);
+        });
+    });
+
+    describe("#generate", () => {
+        describe("Valid order generation", () => {
+            SUCCESSFUL_ORDER_GENERATION.forEach(scenarioRunner.testOrderGenerationScenario);
+        });
+
+        describe("Invalid order generation", () => {
+            UNSUCCESSFUL_ORDER_GENERATION.forEach(scenarioRunner.testOrderGenerationScenario);
         });
     });
 });

--- a/__test__/integration/order_api/order_scenario_runner.ts
+++ b/__test__/integration/order_api/order_scenario_runner.ts
@@ -1,3 +1,9 @@
+// External
+import * as Web3 from "web3";
+import * as compact from "lodash.compact";
+import * as ABIDecoder from "abi-decoder";
+
+// Wrappers
 import {
     DebtKernelContract,
     DebtOrderWrapper,
@@ -6,17 +12,24 @@ import {
     DummyTokenContract,
     SimpleInterestTermsContractContract,
 } from "src/wrappers";
-import { OrderAPI, SignerAPI } from "src/apis";
+
+// APIs
+import { AdaptersAPI, OrderAPI, SignerAPI } from "src/apis";
+
+// Scenarios
 import {
     FillScenario,
     OrderCancellationScenario,
+    OrderGenerationScenario,
     IssuanceCancellationScenario,
 } from "./scenarios/";
-import * as Web3 from "web3";
-import { Web3Utils } from "utils/web3_utils";
+
+// Types
 import { DebtOrder } from "src/types";
-import * as compact from "lodash.compact";
-import * as ABIDecoder from "abi-decoder";
+import { BaseAdapter } from "src/adapters";
+
+// Utils
+import { Web3Utils } from "utils/web3_utils";
 
 export class OrderScenarioRunner {
     public web3Utils: Web3Utils;
@@ -27,6 +40,7 @@ export class OrderScenarioRunner {
     public termsContract: SimpleInterestTermsContractContract;
     public orderApi: OrderAPI;
     public orderSigner: SignerAPI;
+    public adaptersApi: AdaptersAPI;
     public abiDecoder: any;
 
     private currentSnapshotId: number;
@@ -37,6 +51,7 @@ export class OrderScenarioRunner {
         this.testFillScenario = this.testFillScenario.bind(this);
         this.testOrderCancelScenario = this.testOrderCancelScenario.bind(this);
         this.testIssuanceCancelScenario = this.testIssuanceCancelScenario.bind(this);
+        this.testOrderGenerationScenario = this.testOrderGenerationScenario.bind(this);
         this.saveSnapshotAsync = this.saveSnapshotAsync.bind(this);
         this.revertToSavedSnapshot = this.revertToSavedSnapshot.bind(this);
     }
@@ -85,13 +100,13 @@ export class OrderScenarioRunner {
                 // the scenario specifies that a signature from a signatory
                 // ought to be attached.
                 debtOrder.debtorSignature = scenario.signatories.debtor
-                    ? await this.orderSigner.asDebtor(debtOrder)
+                    ? await this.orderSigner.asDebtor(debtOrder, false)
                     : undefined;
                 debtOrder.creditorSignature = scenario.signatories.creditor
-                    ? await this.orderSigner.asCreditor(debtOrder)
+                    ? await this.orderSigner.asCreditor(debtOrder, false)
                     : undefined;
                 debtOrder.underwriterSignature = scenario.signatories.underwriter
-                    ? await this.orderSigner.asUnderwriter(debtOrder)
+                    ? await this.orderSigner.asUnderwriter(debtOrder, false)
                     : undefined;
 
                 if (scenario.beforeBlock) {
@@ -229,6 +244,32 @@ export class OrderScenarioRunner {
                             debtOrderWrapped.getIssuanceCommitment(),
                             { from: scenario.canceller },
                         ),
+                    ).rejects.toThrow(scenario.errorMessage);
+                });
+            }
+        });
+    }
+
+    public testOrderGenerationScenario(scenario: OrderGenerationScenario) {
+        describe(scenario.description, () => {
+            let adapter: BaseAdapter;
+
+            beforeEach(() => {
+                adapter = scenario.adapter(this.adaptersApi);
+            });
+
+            if (!scenario.throws) {
+                test("returns order translated by adapter from input parameters", async () => {
+                    const expectedDebtOrder = await adapter.toDebtOrder(scenario.inputParameters);
+
+                    await expect(
+                        this.orderApi.generate(adapter, scenario.inputParameters),
+                    ).resolves.toEqual(expectedDebtOrder);
+                });
+            } else {
+                test(`should throw ${scenario.errorType}`, async () => {
+                    await expect(
+                        this.orderApi.generate(adapter, scenario.inputParameters),
                     ).rejects.toThrow(scenario.errorMessage);
                 });
             }

--- a/__test__/integration/order_api/order_scenario_runner.ts
+++ b/__test__/integration/order_api/order_scenario_runner.ts
@@ -101,13 +101,13 @@ export class OrderScenarioRunner {
                 // ought to be attached.
                 debtOrder.debtorSignature = scenario.signatories.debtor
                     ? await this.orderSigner.asDebtor(debtOrder, false)
-                    : undefined;
+                    : null;
                 debtOrder.creditorSignature = scenario.signatories.creditor
                     ? await this.orderSigner.asCreditor(debtOrder, false)
-                    : undefined;
+                    : null;
                 debtOrder.underwriterSignature = scenario.signatories.underwriter
                     ? await this.orderSigner.asUnderwriter(debtOrder, false)
-                    : undefined;
+                    : null;
 
                 if (scenario.beforeBlock) {
                     await scenario.beforeBlock(debtOrder, this.debtKernel);

--- a/__test__/integration/order_api/scenarios/index.ts
+++ b/__test__/integration/order_api/scenarios/index.ts
@@ -1,9 +1,15 @@
+// External
+import { BigNumber } from "bignumber.js";
+
+// Wrappers
 import {
     DebtKernelContract,
     RepaymentRouterContract,
     DummyTokenContract,
     SimpleInterestTermsContractContract,
 } from "src/wrappers";
+
+// Scenarios
 import { VALID_ORDERS } from "./valid_orders";
 import { INVALID_ORDERS } from "./invalid_orders";
 import { NONCONSENUAL_ORDERS } from "./nonconsensual_orders";
@@ -11,12 +17,13 @@ import { VALID_ORDER_CANCELLATIONS } from "./valid_order_cancellations";
 import { VALID_ISSUANCE_CANCELLATIONS } from "./valid_issuance_cancellations";
 import { INVALID_ORDER_CANCELLATIONS } from "./invalid_order_cancellations";
 import { INVALID_ISSUANCE_CANCELLATIONS } from "./invalid_issuance_cancellations";
+import { SUCCESSFUL_ORDER_GENERATION } from "./successful_order_generation";
+import { UNSUCCESSFUL_ORDER_GENERATION } from "./unsuccessful_order_generation";
 
-import * as Units from "utils/units";
-import { NULL_ADDRESS, NULL_BYTES32 } from "utils/constants";
-import * as moment from "moment";
-import { BigNumber } from "bignumber.js";
+// Types
 import { DebtOrder } from "src/types";
+import { BaseAdapter } from "src/adapters";
+import { AdaptersAPI } from "src/apis";
 
 export interface FillScenario {
     description: string;
@@ -59,6 +66,15 @@ export interface OrderCancellationScenario {
 // interface as an IssuanceCancellationScenario
 export interface IssuanceCancellationScenario extends OrderCancellationScenario {}
 
+export interface OrderGenerationScenario {
+    description: string;
+    adapter: (adaptersApi: AdaptersAPI) => BaseAdapter;
+    inputParameters: object;
+    throws: boolean;
+    errorType?: string;
+    errorMessage?: string;
+}
+
 export {
     VALID_ORDERS,
     INVALID_ORDERS,
@@ -67,4 +83,6 @@ export {
     INVALID_ORDER_CANCELLATIONS,
     INVALID_ISSUANCE_CANCELLATIONS,
     NONCONSENUAL_ORDERS,
+    SUCCESSFUL_ORDER_GENERATION,
+    UNSUCCESSFUL_ORDER_GENERATION,
 };

--- a/__test__/integration/order_api/scenarios/successful_order_generation.ts
+++ b/__test__/integration/order_api/scenarios/successful_order_generation.ts
@@ -1,0 +1,26 @@
+// External
+import { BigNumber } from "bignumber.js";
+
+// APIs
+import { AdaptersAPI } from "src/apis";
+
+// Types
+import { OrderGenerationScenario } from "./";
+
+// Utils
+import * as Units from "utils/units";
+
+export const SUCCESSFUL_ORDER_GENERATION: OrderGenerationScenario[] = [
+    {
+        description: "using simple interest loan adapter with valid input parameters",
+        adapter: (adaptersApi: AdaptersAPI) => adaptersApi.simpleInterestLoan,
+        inputParameters: {
+            principalAmount: Units.ether(1),
+            principalTokenSymbol: "REP",
+            interestRate: new BigNumber(0.123),
+            amortizationUnit: "days",
+            termLength: new BigNumber(7),
+        },
+        throws: false,
+    },
+];

--- a/__test__/integration/order_api/scenarios/successful_order_generation.ts
+++ b/__test__/integration/order_api/scenarios/successful_order_generation.ts
@@ -23,4 +23,20 @@ export const SUCCESSFUL_ORDER_GENERATION: OrderGenerationScenario[] = [
         },
         throws: false,
     },
+    {
+        description:
+            "using collateralized simple interest loan adapter with valid input parameters",
+        adapter: (adaptersApi: AdaptersAPI) => adaptersApi.collateralizedSimpleInterestLoan,
+        inputParameters: {
+            principalAmount: Units.ether(1),
+            principalTokenSymbol: "ZRX",
+            interestRate: new BigNumber(4.135),
+            amortizationUnit: "months",
+            termLength: new BigNumber(3),
+            collateralTokenSymbol: "MKR",
+            collateralAmount: Units.ether(2),
+            gracePeriodInDays: new BigNumber(3),
+        },
+        throws: false,
+    },
 ];

--- a/__test__/integration/order_api/scenarios/unsuccessful_order_generation.ts
+++ b/__test__/integration/order_api/scenarios/unsuccessful_order_generation.ts
@@ -3,6 +3,7 @@ import { BigNumber } from "bignumber.js";
 
 // APIs
 import { AdaptersAPI } from "src/apis";
+import { ContractsError } from "src/apis/contracts_api";
 
 // Types
 import { OrderGenerationScenario } from "./";
@@ -20,10 +21,63 @@ export const UNSUCCESSFUL_ORDER_GENERATION: OrderGenerationScenario[] = [
             interestRate: new BigNumber(0.32),
             amortizationUnit: "days",
             // We omit the termLength required parameter
-            //  termLength: 7,
+            //  termLength: new BigNumber(7),
         },
         throws: true,
         errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
         errorMessage: 'requires property "termLength"',
+    },
+    {
+        description: "using simple interest loan adapter with invalid input parameters",
+        adapter: (adaptersApi: AdaptersAPI) => adaptersApi.simpleInterestLoan,
+        inputParameters: {
+            principalAmount: Units.ether(1),
+            principalTokenSymbol: "REP",
+            interestRate: new BigNumber(0.32),
+            amortizationUnit: "invalid amortization unit",
+            termLength: new BigNumber(7),
+        },
+        throws: true,
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'does not match pattern "^((hours)|(days)|(weeks)|(months)|(years))$"',
+    },
+    {
+        description:
+            "using collateralized simple interest loan adapter with incomplete input parameters",
+        adapter: (adaptersApi: AdaptersAPI) => adaptersApi.collateralizedSimpleInterestLoan,
+        inputParameters: {
+            principalAmount: Units.ether(1),
+            principalTokenSymbol: "REP",
+            interestRate: new BigNumber(0.32),
+            amortizationUnit: "days",
+            termLength: new BigNumber(7),
+            // We omit the collateralTokenSymbol required parameter
+            // collateralTokenSymbol: "MKR",
+            collateralAmount: Units.ether(2),
+            gracePeriodInDays: new BigNumber(3),
+        },
+        throws: true,
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'requires property "collateralTokenSymbol"',
+    },
+    {
+        description:
+            "using collateralized simple interest loan adapter with invalid input parameters",
+        adapter: (adaptersApi: AdaptersAPI) => adaptersApi.collateralizedSimpleInterestLoan,
+        inputParameters: {
+            principalAmount: Units.ether(1),
+            principalTokenSymbol: "REP",
+            interestRate: new BigNumber(0.32),
+            amortizationUnit: "days",
+            termLength: new BigNumber(7),
+            collateralTokenSymbol: "invalid collateral token symbol",
+            collateralAmount: Units.ether(2),
+            gracePeriodInDays: new BigNumber(3),
+        },
+        throws: true,
+        errorType: "CANNOT_FIND_TOKEN_WITH_SYMBOL",
+        errorMessage: ContractsError.CANNOT_FIND_TOKEN_WITH_SYMBOL(
+            "invalid collateral token symbol",
+        ),
     },
 ];

--- a/__test__/integration/order_api/scenarios/unsuccessful_order_generation.ts
+++ b/__test__/integration/order_api/scenarios/unsuccessful_order_generation.ts
@@ -1,0 +1,29 @@
+// External
+import { BigNumber } from "bignumber.js";
+
+// APIs
+import { AdaptersAPI } from "src/apis";
+
+// Types
+import { OrderGenerationScenario } from "./";
+
+// Utils
+import * as Units from "utils/units";
+
+export const UNSUCCESSFUL_ORDER_GENERATION: OrderGenerationScenario[] = [
+    {
+        description: "using simple interest loan adapter with incomplete input parameters",
+        adapter: (adaptersApi: AdaptersAPI) => adaptersApi.simpleInterestLoan,
+        inputParameters: {
+            principalAmount: Units.ether(1),
+            principalTokenSymbol: "REP",
+            interestRate: new BigNumber(0.32),
+            amortizationUnit: "days",
+            // We omit the termLength required parameter
+            //  termLength: 7,
+        },
+        throws: true,
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'requires property "termLength"',
+    },
+];

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -1,7 +1,14 @@
 import { DebtOrder, DebtRegistryEntry } from "../types";
 
-export abstract class BaseAdapter {
-    public static conformsToAdapterInterface(object: any): object is BaseAdapter {
+export namespace Adapter {
+    export interface Interface {
+        fromDebtOrder: (debtOrder: DebtOrder.Instance) => Promise<object>;
+        toDebtOrder: (params: object) => Promise<DebtOrder.Instance>;
+        fromDebtRegistryEntry: (entry: DebtRegistryEntry) => Promise<object>;
+        getRepaymentSchedule: (entry: DebtRegistryEntry) => Array<number>;
+    }
+
+    export function conformsToAdapterInterface(object: any): object is Interface {
         return (
             "fromDebtOrder" in object &&
             "toDebtOrder" in object &&
@@ -13,9 +20,4 @@ export abstract class BaseAdapter {
             typeof object.getRepaymentSchedule === "function"
         );
     }
-
-    public abstract async fromDebtOrder(debtOrder: DebtOrder.Instance): Promise<object>;
-    public abstract async toDebtOrder(params: object): Promise<DebtOrder.Instance>;
-    public abstract async fromDebtRegistryEntry(entry: DebtRegistryEntry): Promise<object>;
-    public abstract getRepaymentSchedule(entry: DebtRegistryEntry): Array<number>;
 }

--- a/src/adapters/base_adapter.ts
+++ b/src/adapters/base_adapter.ts
@@ -1,0 +1,21 @@
+import { DebtOrder, DebtRegistryEntry } from "../types";
+
+export abstract class BaseAdapter {
+    public static conformsToAdapterInterface(object: any): object is BaseAdapter {
+        return (
+            "fromDebtOrder" in object &&
+            "toDebtOrder" in object &&
+            "fromDebtRegistryEntry" in object &&
+            "getRepaymentSchedule" in object &&
+            typeof object.fromDebtOrder === "function" &&
+            typeof object.toDebtOrder === "function" &&
+            typeof object.fromDebtRegistryEntry === "function" &&
+            typeof object.getRepaymentSchedule === "function"
+        );
+    }
+
+    public abstract async fromDebtOrder(debtOrder: DebtOrder.Instance): Promise<object>;
+    public abstract async toDebtOrder(params: object): Promise<DebtOrder.Instance>;
+    public abstract async fromDebtRegistryEntry(entry: DebtRegistryEntry): Promise<object>;
+    public abstract getRepaymentSchedule(entry: DebtRegistryEntry): Array<number>;
+}

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -6,7 +6,7 @@ import { BigNumber } from "utils/bignumber";
 
 import { ContractsAPI } from "src/apis";
 import { Assertions } from "src/invariants";
-import { DebtOrder, DebtRegistryEntry } from "src/types";
+import { DebtOrder, DebtRegistryEntry, RepaymentSchedule } from "src/types";
 import { BaseAdapter } from "./base_adapter";
 
 import { TermsContractParameters } from "./terms_contract_parameters";
@@ -285,6 +285,17 @@ export class CollateralizedSimpleInterestLoanAdapter extends BaseAdapter {
         };
 
         return loanOrder;
+    }
+
+    public getRepaymentSchedule(debtEntry: DebtRegistryEntry): Array<number> {
+        const { termsContractParameters, issuanceBlockTimestamp } = debtEntry;
+        const { termLength, amortizationUnit } = this.unpackParameters(termsContractParameters);
+
+        return new RepaymentSchedule(
+            amortizationUnit,
+            termLength,
+            issuanceBlockTimestamp.toNumber(),
+        ).toArray();
     }
 
     private unpackParameters(

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -7,7 +7,7 @@ import { BigNumber } from "utils/bignumber";
 import { ContractsAPI } from "src/apis";
 import { Assertions } from "src/invariants";
 import { DebtOrder, DebtRegistryEntry, RepaymentSchedule } from "src/types";
-import { BaseAdapter } from "./base_adapter";
+import { Adapter } from "./adapter";
 
 import { TermsContractParameters } from "./terms_contract_parameters";
 import {
@@ -144,15 +144,13 @@ export class CollateralizedLoanTerms {
     }
 }
 
-export class CollateralizedSimpleInterestLoanAdapter extends BaseAdapter {
+export class CollateralizedSimpleInterestLoanAdapter implements Adapter.Interface {
     private assert: Assertions;
     private contractsAPI: ContractsAPI;
     private simpleInterestLoanTerms: SimpleInterestLoanTerms;
     private collateralizedLoanTerms: CollateralizedLoanTerms;
 
     public constructor(web3: Web3, contractsAPI: ContractsAPI) {
-        super();
-
         this.assert = new Assertions(web3, contractsAPI);
         this.contractsAPI = contractsAPI;
         this.simpleInterestLoanTerms = new SimpleInterestLoanTerms(web3, contractsAPI);

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -7,6 +7,7 @@ import { BigNumber } from "utils/bignumber";
 import { ContractsAPI } from "src/apis";
 import { Assertions } from "src/invariants";
 import { DebtOrder, DebtRegistryEntry } from "src/types";
+import { BaseAdapter } from "./base_adapter";
 
 import { TermsContractParameters } from "./terms_contract_parameters";
 import {
@@ -143,13 +144,15 @@ export class CollateralizedLoanTerms {
     }
 }
 
-export class CollateralizedSimpleInterestLoanAdapter {
+export class CollateralizedSimpleInterestLoanAdapter extends BaseAdapter {
     private assert: Assertions;
     private contractsAPI: ContractsAPI;
     private simpleInterestLoanTerms: SimpleInterestLoanTerms;
     private collateralizedLoanTerms: CollateralizedLoanTerms;
 
     public constructor(web3: Web3, contractsAPI: ContractsAPI) {
+        super();
+
         this.assert = new Assertions(web3, contractsAPI);
         this.contractsAPI = contractsAPI;
         this.simpleInterestLoanTerms = new SimpleInterestLoanTerms(web3, contractsAPI);

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,5 +1,5 @@
-import { BaseAdapter } from "./base_adapter";
+import { Adapter } from "./adapter";
 import { SimpleInterestLoanAdapter } from "./simple_interest_loan_adapter";
 import { CollateralizedSimpleInterestLoanAdapter } from "./collateralized_simple_interest_loan_adapter";
 
-export { BaseAdapter, SimpleInterestLoanAdapter, CollateralizedSimpleInterestLoanAdapter };
+export { Adapter, SimpleInterestLoanAdapter, CollateralizedSimpleInterestLoanAdapter };

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,4 +1,5 @@
+import { BaseAdapter } from "./base_adapter";
 import { SimpleInterestLoanAdapter } from "./simple_interest_loan_adapter";
 import { CollateralizedSimpleInterestLoanAdapter } from "./collateralized_simple_interest_loan_adapter";
 
-export { SimpleInterestLoanAdapter, CollateralizedSimpleInterestLoanAdapter };
+export { BaseAdapter, SimpleInterestLoanAdapter, CollateralizedSimpleInterestLoanAdapter };

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -13,6 +13,7 @@ import { DebtOrder, RepaymentSchedule } from "../types";
 import { ContractsAPI } from "../apis";
 import { Assertions } from "../invariants";
 import { DebtRegistryEntry } from "../types/debt_registry_entry";
+import { BaseAdapter } from "./base_adapter";
 
 export interface SimpleInterestLoanOrder extends DebtOrder.Instance {
     // Required Debt Order Parameters
@@ -221,7 +222,7 @@ export class SimpleInterestLoanTerms {
     }
 }
 
-export class SimpleInterestLoanAdapter {
+export class SimpleInterestLoanAdapter extends BaseAdapter {
     public static Installments: { [type: string]: AmortizationUnit } = {
         HOURLY: "hours",
         DAILY: "days",
@@ -235,6 +236,8 @@ export class SimpleInterestLoanAdapter {
     private termsContractInterface: SimpleInterestLoanTerms;
 
     public constructor(web3: Web3, contracts: ContractsAPI) {
+        super();
+
         this.assert = new Assertions(web3, contracts);
         this.contracts = contracts;
         this.termsContractInterface = new SimpleInterestLoanTerms(web3, contracts);

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -13,7 +13,7 @@ import { DebtOrder, RepaymentSchedule } from "../types";
 import { ContractsAPI } from "../apis";
 import { Assertions } from "../invariants";
 import { DebtRegistryEntry } from "../types/debt_registry_entry";
-import { BaseAdapter } from "./base_adapter";
+import { Adapter } from "./adapter";
 
 export interface SimpleInterestLoanOrder extends DebtOrder.Instance {
     // Required Debt Order Parameters
@@ -222,7 +222,7 @@ export class SimpleInterestLoanTerms {
     }
 }
 
-export class SimpleInterestLoanAdapter extends BaseAdapter {
+export class SimpleInterestLoanAdapter implements Adapter.Interface {
     public static Installments: { [type: string]: AmortizationUnit } = {
         HOURLY: "hours",
         DAILY: "days",
@@ -236,8 +236,6 @@ export class SimpleInterestLoanAdapter extends BaseAdapter {
     private termsContractInterface: SimpleInterestLoanTerms;
 
     public constructor(web3: Web3, contracts: ContractsAPI) {
-        super();
-
         this.assert = new Assertions(web3, contracts);
         this.contracts = contracts;
         this.termsContractInterface = new SimpleInterestLoanTerms(web3, contracts);

--- a/src/apis/adapters_api.ts
+++ b/src/apis/adapters_api.ts
@@ -1,6 +1,6 @@
 import * as Web3 from "web3";
 import { ContractsAPI } from "./";
-import { SimpleInterestLoanAdapter } from "../adapters";
+import { SimpleInterestLoanAdapter, CollateralizedSimpleInterestLoanAdapter } from "../adapters";
 
 export class AdaptersAPI {
     /**
@@ -21,6 +21,7 @@ export class AdaptersAPI {
      * 10 ether * 2 years * 10% = 2 ether
      */
     public simpleInterestLoan: SimpleInterestLoanAdapter;
+    public collateralizedSimpleInterestLoan: CollateralizedSimpleInterestLoanAdapter;
 
     private contracts: ContractsAPI;
     private web3: Web3;
@@ -30,5 +31,9 @@ export class AdaptersAPI {
         this.contracts = contractsApi;
 
         this.simpleInterestLoan = new SimpleInterestLoanAdapter(this.web3, this.contracts);
+        this.collateralizedSimpleInterestLoan = new CollateralizedSimpleInterestLoanAdapter(
+            this.web3,
+            this.contracts,
+        );
     }
 }

--- a/src/apis/order_api.ts
+++ b/src/apis/order_api.ts
@@ -78,7 +78,7 @@ export const OrderAPIErrors = {
         singleLineString`Underwriter signature is not valid for debt order`,
 
     ADAPTER_DOES_NOT_CONFORM_TO_INTERFACE: () =>
-        singleLineString`Supplied adapter does not conform to the required
+        singleLineString`Supplied adapter does not conform to the
                          base adapter interface.`,
 };
 
@@ -215,7 +215,7 @@ export class OrderAPI {
      * parameters object.
      *
      * @param adapter The adapter to be leveraged in generating this particular debt
-     *                order
+     *                order.
      * @param params  The parameters that will be used by the aforementioned adapter
      *                to generate the debt order.
      * @return Newly generated debt order.

--- a/src/invariants/adapter.ts
+++ b/src/invariants/adapter.ts
@@ -1,0 +1,9 @@
+import { BaseAdapter } from "../adapters";
+
+export class AdapterAssertions {
+    public conformsToInterface(object: any, errorMessage: string): void {
+        if (!BaseAdapter.conformsToAdapterInterface(object)) {
+            throw new Error(errorMessage);
+        }
+    }
+}

--- a/src/invariants/adapter.ts
+++ b/src/invariants/adapter.ts
@@ -1,8 +1,8 @@
-import { BaseAdapter } from "../adapters";
+import { Adapter } from "../adapters";
 
 export class AdapterAssertions {
     public conformsToInterface(object: any, errorMessage: string): void {
-        if (!BaseAdapter.conformsToAdapterInterface(object)) {
+        if (!Adapter.conformsToAdapterInterface(object)) {
             throw new Error(errorMessage);
         }
     }

--- a/src/invariants/index.ts
+++ b/src/invariants/index.ts
@@ -3,6 +3,7 @@ import * as Web3 from "web3";
 
 // Assertions
 import { AccountAssertions } from "./account";
+import { AdapterAssertions } from "./adapter";
 import { TokenAssertions } from "./token";
 import { OrderAssertions } from "./order";
 import { SchemaAssertions } from "./schema";
@@ -13,6 +14,7 @@ import { ContractsAPI } from "../apis/";
 
 export class Assertions {
     public account: AccountAssertions;
+    public adapter: AdapterAssertions;
     public order: OrderAssertions;
     public token: TokenAssertions;
     public schema: SchemaAssertions;
@@ -26,6 +28,7 @@ export class Assertions {
         this.contracts = contracts;
 
         this.account = new AccountAssertions(this.web3);
+        this.adapter = new AdapterAssertions();
         this.order = new OrderAssertions(this.contracts);
         this.token = new TokenAssertions();
         this.schema = new SchemaAssertions();


### PR DESCRIPTION
This PR introduces the following changes:

- Adds a `generate` method to the order API, as described [in Pivotal](https://www.pivotaltracker.com/story/show/156491745)
- Add `getRepaymentSchedule` method to the collateralized simple interest loan adapter
- Add basic test suite for `generate`