### PR TITLE
Bumped charta to 0.0.27

### DIFF
--- a/__test__/integration/servicing_api/runners/make_repayment.ts
+++ b/__test__/integration/servicing_api/runners/make_repayment.ts
@@ -187,6 +187,7 @@ export class MakeRepaymentRunner {
                 if (scenario.successfullyRepays) {
                     test("should emit log indicating successful repayment", async () => {
                         const receipt = await web3Utils.getTransactionReceiptAsync(txHash);
+
                         const [repaymentSuccessLog] = compact(ABIDecoder.decodeLogs(receipt.logs));
 
                         expect(repaymentSuccessLog.name).toBe("LogRepayment");

--- a/__test__/integration/servicing_api/scenarios/get_expected_value_repaid.ts
+++ b/__test__/integration/servicing_api/scenarios/get_expected_value_repaid.ts
@@ -21,7 +21,7 @@ export const GET_EXPECTED_VALUE_REPAID: GetExpectedValueRepaidScenario[] = [
         principalAmount: Units.ether(1),
         interestRate: new BigNumber(0.1),
         amortizationUnit: "months",
-        expected: Units.ether(0.6),
+        expected: Units.ether(0.55),
     },
     {
         description: "in 61 days at 10% interest amortized monthly from 1 Ether principal",
@@ -29,7 +29,7 @@ export const GET_EXPECTED_VALUE_REPAID: GetExpectedValueRepaidScenario[] = [
         principalAmount: Units.ether(1),
         interestRate: new BigNumber(0.1),
         amortizationUnit: "months",
-        expected: Units.ether(1.2),
+        expected: Units.ether(1.1),
     },
     {
         description: "in 0 days at 20% interest amortized monthly from 1 Ether principal",
@@ -45,7 +45,7 @@ export const GET_EXPECTED_VALUE_REPAID: GetExpectedValueRepaidScenario[] = [
         principalAmount: Units.ether(1),
         interestRate: new BigNumber(0.2),
         amortizationUnit: "months",
-        expected: Units.ether(0.7),
+        expected: Units.ether(0.6),
     },
     {
         description: "in 61 days at 20% interest amortized monthly from 1 Ether principal",
@@ -53,6 +53,6 @@ export const GET_EXPECTED_VALUE_REPAID: GetExpectedValueRepaidScenario[] = [
         principalAmount: Units.ether(1),
         interestRate: new BigNumber(0.2),
         amortizationUnit: "months",
-        expected: Units.ether(1.4),
+        expected: Units.ether(1.2),
     },
 ];

--- a/__test__/unit/blockchain_api/error_scenario_runner.ts
+++ b/__test__/unit/blockchain_api/error_scenario_runner.ts
@@ -5,7 +5,7 @@ import { BigNumber } from "bignumber.js";
 import { DebtKernelErrorScenario, RepaymentRouterErrorScenario } from "./scenarios";
 import { DebtOrder, DebtKernelError, RepaymentRouterError } from "src/types";
 import { Web3Utils } from "utils/web3_utils";
-import { ContractsAPI, BlockchainAPI, SignerAPI, OrderAPI } from "src/apis/";
+import { AdaptersAPI, ContractsAPI, BlockchainAPI, SignerAPI, OrderAPI } from "src/apis/";
 import { SimpleInterestLoanAdapter } from "src/adapters";
 
 import {
@@ -43,6 +43,7 @@ export class ErrorScenarioRunner {
     private tokenRegistry: TokenRegistryContract;
 
     // APIs
+    private adaptersAPI: AdaptersAPI;
     private contractsAPI: ContractsAPI;
     private blockchainAPI: BlockchainAPI;
     private signerAPI: SignerAPI;
@@ -71,7 +72,6 @@ export class ErrorScenarioRunner {
         }
 
         // Construct all necessary dependencies.
-
         this.contractsAPI = new ContractsAPI(this.web3);
         this.blockchainAPI = new BlockchainAPI(this.web3, this.contractsAPI);
         this.signerAPI = new SignerAPI(this.web3, this.contractsAPI);
@@ -190,6 +190,7 @@ export class ErrorScenarioRunner {
                     debtOrder.creditor,
                     creditorBalance,
                 );
+
                 await this.principalToken.approve.sendTransactionAsync(
                     this.tokenTransferProxy.address,
                     creditorAllowance,
@@ -302,7 +303,7 @@ export class ErrorScenarioRunner {
             salt: new BigNumber(0),
         });
 
-        debtOrder.debtorSignature = await this.signerAPI.asDebtor(debtOrder);
+        debtOrder.debtorSignature = await this.signerAPI.asDebtor(debtOrder, false);
 
         return debtOrder;
     }

--- a/__test__/unit/debt_token_wrapper.spec.ts
+++ b/__test__/unit/debt_token_wrapper.spec.ts
@@ -67,18 +67,10 @@ describe("Debt Token Contract Wrapper (Unit)", () => {
 
         describe("balanceOf", () => {
             describe("callAsync()", () => {
-                test("returns 0 when called with null address", async () => {
-                    const balance = await contractWrapper.balanceOf.callAsync(NULL_ADDRESS);
-                    expect(balance).toEqual(new BigNumber(0));
-                });
-            });
-        });
-
-        describe("implementsERC721", () => {
-            describe("callAsync", () => {
-                test("it returns true", async () => {
-                    const implementsERC721 = await contractWrapper.implementsERC721.callAsync();
-                    expect(implementsERC721).toEqual(true);
+                test("throws when called with null address", async () => {
+                    await expect(
+                        contractWrapper.balanceOf.callAsync(NULL_ADDRESS),
+                    ).rejects.toThrow();
                 });
             });
         });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "main": "dist/dharma.umd.js",
     "module": "dist/lib/src/index.js",
     "typings": "dist/types/src/index.d.ts",
-    "files": ["dist"],
+    "files": [
+        "dist"
+    ],
     "author": "Nadav Hollander <nadav@dharma.io>",
     "repository": {
         "type": "git",
@@ -23,8 +25,7 @@
         "start": "rollup -c rollup.config.ts -w",
         "chain": "bash scripts/init_chain.sh",
         "test": "jest --runInBand",
-        "docs":
-            "typedoc --theme markdown --mdHideSources --name dharma.js --excludePrivate --excludeExternals --excludeProtected --hideGenerator --target ES6 --out generated_docs/ src/apis",
+        "docs": "typedoc --theme markdown --mdHideSources --name dharma.js --excludePrivate --excludeExternals --excludeProtected --hideGenerator --target ES6 --out generated_docs/ src/apis",
         "test:watch": "jest --watch --runInBand",
         "test:prod": "npm run lint && npm run test -- --coverage --no-cache --runInBand",
         "deploy-docs": "ts-node tools/gh-pages-publish",
@@ -37,7 +38,9 @@
         "prettify": "prettier --write {src,__test__,__mocks__}/**/*.ts"
     },
     "lint-staged": {
-        "{src,__test__,__mocks__}/**/*.ts": ["prettier --write"]
+        "{src,__test__,__mocks__}/**/*.ts": [
+            "prettier --write"
+        ]
     },
     "config": {
         "commitizen": {
@@ -45,8 +48,7 @@
         },
         "validate-commit-msg": {
             "types": "conventional-commit-types",
-            "helpMessage":
-                "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
+            "helpMessage": "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
         }
     },
     "jest": {
@@ -54,9 +56,18 @@
             ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
         },
         "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-        "moduleFileExtensions": ["ts", "tsx", "js"],
-        "modulePaths": ["<rootDir>/"],
-        "coveragePathIgnorePatterns": ["/node_modules/", "/test/"],
+        "moduleFileExtensions": [
+            "ts",
+            "tsx",
+            "js"
+        ],
+        "modulePaths": [
+            "<rootDir>/"
+        ],
+        "coveragePathIgnorePatterns": [
+            "/node_modules/",
+            "/test/"
+        ],
         "coverageThreshold": {
             "global": {
                 "branches": 40,
@@ -113,7 +124,7 @@
         "webpack": "^3.11.0"
     },
     "dependencies": {
-        "@dharmaprotocol/contracts": "0.0.26",
+        "@dharmaprotocol/contracts": "0.0.27",
         "@types/lodash": "^4.14.104",
         "abi-decoder": "https://github.com/dharmaprotocol/abi-decoder",
         "bignumber.js": "^5.0.0",

--- a/src/apis/order_api.ts
+++ b/src/apis/order_api.ts
@@ -24,7 +24,7 @@ import { Web3Utils } from "../../utils/web3_utils";
 import { NULL_ADDRESS } from "../../utils/constants";
 import { Assertions } from "../invariants";
 
-const ORDER_FILL_GAS_MAXIMUM = 500000;
+const ORDER_FILL_GAS_MAXIMUM = 600000;
 
 export const OrderAPIErrors = {
     EXPIRED: () =>

--- a/src/apis/servicing_api.ts
+++ b/src/apis/servicing_api.ts
@@ -14,7 +14,7 @@ import { Assertions } from "../invariants";
 import { DebtRegistryEntry, TxData, RepaymentSchedule } from "../types";
 import { SimpleInterestLoanAdapter } from "../adapters/simple_interest_loan_adapter";
 
-const REPAYMENT_GAS_MAXIMUM = 100000;
+const REPAYMENT_GAS_MAXIMUM = 150000;
 
 export const ServicingAPIErrors = {
     DEBT_AGREEMENT_NONEXISTENT: (issuanceHash: string) =>

--- a/src/apis/servicing_api.ts
+++ b/src/apis/servicing_api.ts
@@ -212,9 +212,19 @@ export class ServicingAPI {
         // debt agreements.  Thus, we can retrieve a list of
         // a users' debt agreements by retrieving a list of tokens
         // they own.
-        const usersDebtTokens = await debtToken.getOwnerTokens.callAsync(account);
+        const numInvestments = await debtToken.balanceOf.callAsync(account);
 
-        return usersDebtTokens.map(
+        let userDebtTokenIds = [];
+
+        for (let i = 0; i < numInvestments.toNumber(); i++) {
+            const tokenId = await debtToken.tokenOfOwnerByIndex.callAsync(
+                account,
+                new BigNumber(i),
+            );
+            userDebtTokenIds.push(tokenId);
+        }
+
+        return userDebtTokenIds.map(
             (tokenId: BigNumber) => `0x${tokenId.toString(16).padStart(64, "0")}`,
         );
     }

--- a/src/invariants/debt_agreement.ts
+++ b/src/invariants/debt_agreement.ts
@@ -1,23 +1,15 @@
-import * as Web3 from "web3";
 import { DebtTokenContract } from "../wrappers";
-import { NULL_ADDRESS } from "../../utils/constants";
 import { BigNumber } from "bignumber.js";
 
 export class DebtAgreementAssertions {
-    private web3: Web3;
-
-    constructor(web3: Web3) {
-        this.web3 = web3;
-    }
-
     public async exists(
         issuanceHash: string,
         debtToken: DebtTokenContract,
         errorMessage: string,
     ): Promise<void> {
-        const debtTokenOwner = await debtToken.ownerOf.callAsync(new BigNumber(issuanceHash));
+        const debtAgreementExists = await debtToken.exists.callAsync(new BigNumber(issuanceHash));
 
-        if (debtTokenOwner === NULL_ADDRESS) {
+        if (!debtAgreementExists) {
             throw new Error(errorMessage);
         }
     }

--- a/src/invariants/order.ts
+++ b/src/invariants/order.ts
@@ -75,10 +75,11 @@ export class OrderAssertions {
         debtOrder = await DebtOrder.applyNetworkDefaults(debtOrder, this.contracts);
         const debtOrderWrapped = new DebtOrderWrapper(debtOrder);
 
-        const getOwnerAddress = await debtToken.ownerOf.callAsync(
+        const orderIssued = await debtToken.exists.callAsync(
             new BigNumber(debtOrderWrapped.getIssuanceCommitmentHash()),
         );
-        if (getOwnerAddress !== NULL_ADDRESS) {
+
+        if (orderIssued) {
             throw new Error(errorMessage);
         }
     }

--- a/src/wrappers/contract_wrappers/debt_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_token_wrapper.ts
@@ -14,6 +14,16 @@ import * as Web3 from "web3";
 import { BaseContract, CONTRACT_WRAPPER_ERRORS } from "./base_contract_wrapper";
 
 export class DebtTokenContract extends BaseContract {
+    public supportsInterface = {
+        async callAsync(interfaceID: string, defaultBlock?: Web3.BlockParam): Promise<boolean> {
+            const self = this as DebtTokenContract;
+            const result = await promisify<boolean>(
+                self.web3ContractInstance.supportsInterface.call,
+                self.web3ContractInstance,
+            )(interfaceID);
+            return result;
+        },
+    };
     public getAuthorizedMintAgents = {
         async callAsync(defaultBlock?: Web3.BlockParam): Promise<string[]> {
             const self = this as DebtTokenContract;
@@ -82,16 +92,6 @@ export class DebtTokenContract extends BaseContract {
             const self = this as DebtTokenContract;
             const abiEncodedTransactionData = self.web3ContractInstance.approve.getData();
             return abiEncodedTransactionData;
-        },
-    };
-    public implementsERC721 = {
-        async callAsync(defaultBlock?: Web3.BlockParam): Promise<boolean> {
-            const self = this as DebtTokenContract;
-            const result = await promisify<boolean>(
-                self.web3ContractInstance.implementsERC721.call,
-                self.web3ContractInstance,
-            )();
-            return result;
         },
     };
     public totalSupply = {
@@ -189,44 +189,67 @@ export class DebtTokenContract extends BaseContract {
             return abiEncodedTransactionData;
         },
     };
-    public mint = {
+    public safeTransferFrom = {
         async sendTransactionAsync(
-            _owner: string,
+            _from: string,
+            _to: string,
             _tokenId: BigNumber,
             txData: TxData = {},
         ): Promise<string> {
             const self = this as DebtTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
                 txData,
-                self.mint.estimateGasAsync.bind(self, _owner, _tokenId),
+                self.safeTransferFrom.estimateGasAsync.bind(self, _from, _to, _tokenId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.mint,
+                self.web3ContractInstance.safeTransferFrom,
                 self.web3ContractInstance,
-            )(_owner, _tokenId, txDataWithDefaults);
+            )(_from, _to, _tokenId, txDataWithDefaults);
             return txHash;
         },
         async estimateGasAsync(
-            _owner: string,
+            _from: string,
+            _to: string,
             _tokenId: BigNumber,
             txData: TxData = {},
         ): Promise<number> {
             const self = this as DebtTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.mint.estimateGas,
+                self.web3ContractInstance.safeTransferFrom.estimateGas,
                 self.web3ContractInstance,
-            )(_owner, _tokenId, txDataWithDefaults);
+            )(_from, _to, _tokenId, txDataWithDefaults);
             return gas;
         },
         getABIEncodedTransactionData(
-            _owner: string,
+            _from: string,
+            _to: string,
             _tokenId: BigNumber,
             txData: TxData = {},
         ): string {
             const self = this as DebtTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.mint.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.safeTransferFrom.getData();
             return abiEncodedTransactionData;
+        },
+    };
+    public exists = {
+        async callAsync(_tokenId: BigNumber, defaultBlock?: Web3.BlockParam): Promise<boolean> {
+            const self = this as DebtTokenContract;
+            const result = await promisify<boolean>(
+                self.web3ContractInstance.exists.call,
+                self.web3ContractInstance,
+            )(_tokenId);
+            return result;
+        },
+    };
+    public tokenByIndex = {
+        async callAsync(_index: BigNumber, defaultBlock?: Web3.BlockParam): Promise<BigNumber> {
+            const self = this as DebtTokenContract;
+            const result = await promisify<BigNumber>(
+                self.web3ContractInstance.tokenByIndex.call,
+                self.web3ContractInstance,
+            )(_index);
+            return result;
         },
     };
     public paused = {
@@ -244,16 +267,6 @@ export class DebtTokenContract extends BaseContract {
             const self = this as DebtTokenContract;
             const result = await promisify<string>(
                 self.web3ContractInstance.ownerOf.call,
-                self.web3ContractInstance,
-            )(_tokenId);
-            return result;
-        },
-    };
-    public tokenMetadata = {
-        async callAsync(_tokenId: BigNumber, defaultBlock?: Web3.BlockParam): Promise<string> {
-            const self = this as DebtTokenContract;
-            const result = await promisify<string>(
-                self.web3ContractInstance.tokenMetadata.call,
                 self.web3ContractInstance,
             )(_tokenId);
             return result;
@@ -471,6 +484,42 @@ export class DebtTokenContract extends BaseContract {
             return abiEncodedTransactionData;
         },
     };
+    public setApprovalForAll = {
+        async sendTransactionAsync(
+            _to: string,
+            _approved: boolean,
+            txData: TxData = {},
+        ): Promise<string> {
+            const self = this as DebtTokenContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
+                txData,
+                self.setApprovalForAll.estimateGasAsync.bind(self, _to, _approved),
+            );
+            const txHash = await promisify<string>(
+                self.web3ContractInstance.setApprovalForAll,
+                self.web3ContractInstance,
+            )(_to, _approved, txDataWithDefaults);
+            return txHash;
+        },
+        async estimateGasAsync(
+            _to: string,
+            _approved: boolean,
+            txData: TxData = {},
+        ): Promise<number> {
+            const self = this as DebtTokenContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
+            const gas = await promisify<number>(
+                self.web3ContractInstance.setApprovalForAll.estimateGas,
+                self.web3ContractInstance,
+            )(_to, _approved, txDataWithDefaults);
+            return gas;
+        },
+        getABIEncodedTransactionData(_to: string, _approved: boolean, txData: TxData = {}): string {
+            const self = this as DebtTokenContract;
+            const abiEncodedTransactionData = self.web3ContractInstance.setApprovalForAll.getData();
+            return abiEncodedTransactionData;
+        },
+    };
     public transfer = {
         async sendTransactionAsync(
             _to: string,
@@ -511,23 +560,73 @@ export class DebtTokenContract extends BaseContract {
             return abiEncodedTransactionData;
         },
     };
-    public numTokensTotal = {
-        async callAsync(defaultBlock?: Web3.BlockParam): Promise<BigNumber> {
+    public safeTransferFrom = {
+        async sendTransactionAsync(
+            _from: string,
+            _to: string,
+            _tokenId: BigNumber,
+            _data: string,
+            txData: TxData = {},
+        ): Promise<string> {
             const self = this as DebtTokenContract;
-            const result = await promisify<BigNumber>(
-                self.web3ContractInstance.numTokensTotal.call,
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
+                txData,
+                self.safeTransferFrom.estimateGasAsync.bind(self, _from, _to, _tokenId, _data),
+            );
+            const txHash = await promisify<string>(
+                self.web3ContractInstance.safeTransferFrom,
                 self.web3ContractInstance,
-            )();
+            )(_from, _to, _tokenId, _data, txDataWithDefaults);
+            return txHash;
+        },
+        async estimateGasAsync(
+            _from: string,
+            _to: string,
+            _tokenId: BigNumber,
+            _data: string,
+            txData: TxData = {},
+        ): Promise<number> {
+            const self = this as DebtTokenContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
+            const gas = await promisify<number>(
+                self.web3ContractInstance.safeTransferFrom.estimateGas,
+                self.web3ContractInstance,
+            )(_from, _to, _tokenId, _data, txDataWithDefaults);
+            return gas;
+        },
+        getABIEncodedTransactionData(
+            _from: string,
+            _to: string,
+            _tokenId: BigNumber,
+            _data: string,
+            txData: TxData = {},
+        ): string {
+            const self = this as DebtTokenContract;
+            const abiEncodedTransactionData = self.web3ContractInstance.safeTransferFrom.getData();
+            return abiEncodedTransactionData;
+        },
+    };
+    public tokenURI = {
+        async callAsync(_tokenId: BigNumber, defaultBlock?: Web3.BlockParam): Promise<string> {
+            const self = this as DebtTokenContract;
+            const result = await promisify<string>(
+                self.web3ContractInstance.tokenURI.call,
+                self.web3ContractInstance,
+            )(_tokenId);
             return result;
         },
     };
-    public getOwnerTokens = {
-        async callAsync(_owner: string, defaultBlock?: Web3.BlockParam): Promise<BigNumber[]> {
+    public isApprovedForAll = {
+        async callAsync(
+            _owner: string,
+            _operator: string,
+            defaultBlock?: Web3.BlockParam,
+        ): Promise<boolean> {
             const self = this as DebtTokenContract;
-            const result = await promisify<BigNumber[]>(
-                self.web3ContractInstance.getOwnerTokens.call,
+            const result = await promisify<boolean>(
+                self.web3ContractInstance.isApprovedForAll.call,
                 self.web3ContractInstance,
-            )(_owner);
+            )(_owner, _operator);
             return result;
         },
     };

--- a/utils/web3_utils.ts
+++ b/utils/web3_utils.ts
@@ -35,7 +35,6 @@ export class Web3Utils {
     }
 
     public async getTransactionReceiptAsync(txHash: string): Promise<Web3.TransactionReceipt> {
-        console.log("before");
         return promisify(this.web3.eth.getTransactionReceipt)(txHash);
     }
 

--- a/utils/web3_utils.ts
+++ b/utils/web3_utils.ts
@@ -35,6 +35,7 @@ export class Web3Utils {
     }
 
     public async getTransactionReceiptAsync(txHash: string): Promise<Web3.TransactionReceipt> {
+        console.log("before");
         return promisify(this.web3.eth.getTransactionReceipt)(txHash);
     }
 
@@ -48,12 +49,17 @@ export class Web3Utils {
         return response.result;
     }
 
-    private async sendJsonRpcRequestAsync(method: string, params: any[]): Promise<Web3.JSONRPCResponsePayload> {
-        return promisify(this.web3.currentProvider.sendAsync, { context: this.web3.currentProvider })({
+    private async sendJsonRpcRequestAsync(
+        method: string,
+        params: any[],
+    ): Promise<Web3.JSONRPCResponsePayload> {
+        return promisify(this.web3.currentProvider.sendAsync, {
+            context: this.web3.currentProvider,
+        })({
             jsonrpc: "2.0",
             method,
             params,
-            id: new Date().getTime()
+            id: new Date().getTime(),
         });
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,12 +132,11 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dharmaprotocol/contracts@0.0.26":
-  version "0.0.26"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.26.tgz#fc88ab32f0074758234f420bc631ef5e1f651566"
+"@dharmaprotocol/contracts@0.0.27":
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.27.tgz#5015879e5e96d2eb2748ef37661f581d2978da42"
   dependencies:
-    NonFungibleToken "https://github.com/dharmaprotocol/NonFungibleToken.git"
-    zeppelin-solidity "^1.6.0"
+    zeppelin-solidity "^1.8.0"
 
 "@marionebl/sander@^0.6.0":
   version "0.6.1"
@@ -305,12 +304,6 @@ JSONStream@^1.0.4:
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
-
-"NonFungibleToken@https://github.com/dharmaprotocol/NonFungibleToken.git":
-  version "0.0.1"
-  resolved "https://github.com/dharmaprotocol/NonFungibleToken.git#3a45b200d14be1e1fc454f4b0fbf7f7b0d81f133"
-  dependencies:
-    zeppelin-solidity "^1.4.0"
 
 abab@^1.0.3, abab@^1.0.4:
   version "1.0.4"
@@ -8600,9 +8593,9 @@ yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
 
-zeppelin-solidity@^1.4.0, zeppelin-solidity@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/zeppelin-solidity/-/zeppelin-solidity-1.7.0.tgz#c43332926b6e84a845015c21753064eeac054df0"
+zeppelin-solidity@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/zeppelin-solidity/-/zeppelin-solidity-1.8.0.tgz#049fcde7daea9fc85210f8c6db9f8cd1ab8a853a"
   dependencies:
     dotenv "^4.0.0"
     ethjs-abi "^0.2.1"


### PR DESCRIPTION
This PR introduces the following changes:

- Bump `@dharmaprotocol/contracts` to 0.0.27
- Fix `DebtTokenContractWrapper` to correspond to new 721 interface
- Fix a whole slew of errors that emerged as a result of the change.