### PR TITLE
fix: rename collateralizedAdapter to collateralizerAdapter

### DIFF
--- a/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
@@ -33,7 +33,7 @@ import { DebtOrder, DebtRegistryEntry } from "src/types";
 import {
     CollateralizedSimpleInterestLoanAdapter,
     CollateralizedLoanTerms,
-    CollateralizedAdapterErrors,
+    CollateralizerAdapterErrors,
     CollateralizedTermsContractParameters,
     CollateralizedSimpleInterestLoanOrder,
 } from "src/adapters/collateralized_simple_interest_loan_adapter";
@@ -115,7 +115,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                         collateralTokenIndex: invalidCollateralTokenIndex,
                     });
                 }).toThrow(
-                    CollateralizedAdapterErrors.INVALID_TOKEN_INDEX(invalidCollateralTokenIndex),
+                    CollateralizerAdapterErrors.INVALID_TOKEN_INDEX(invalidCollateralTokenIndex),
                 );
             });
         });
@@ -126,7 +126,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                         ...scenario_1.unpackedParams,
                         collateralAmount: new BigNumber(3.5 * 10 ** 38),
                     });
-                }).toThrow(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM());
+                }).toThrow(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM());
             });
         });
         describe("...with collateral amount < 0", () => {
@@ -136,7 +136,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                         ...scenario_1.unpackedParams,
                         collateralAmount: new BigNumber(-1),
                     });
-                }).toThrow(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
+                }).toThrow(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
             });
         });
         describe("...with collateral amount containing decimals", () => {
@@ -146,7 +146,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                         ...scenario_1.unpackedParams,
                         collateralAmount: new BigNumber(100.4567),
                     });
-                }).toThrowError(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+                }).toThrowError(CollateralizerAdapterErrors.INVALID_DECIMAL_VALUE());
             });
         });
         describe("...with grace period in days < 0", () => {
@@ -156,7 +156,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                         ...scenario_1.unpackedParams,
                         gracePeriodInDays: new BigNumber(-1),
                     });
-                }).toThrowError(CollateralizedAdapterErrors.GRACE_PERIOD_IS_NEGATIVE());
+                }).toThrowError(CollateralizerAdapterErrors.GRACE_PERIOD_IS_NEGATIVE());
             });
         });
         describe("...with grace period in days > 255", () => {
@@ -166,7 +166,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                         ...scenario_1.unpackedParams,
                         gracePeriodInDays: new BigNumber(256),
                     });
-                }).toThrowError(CollateralizedAdapterErrors.GRACE_PERIOD_EXCEEDS_MAXIMUM());
+                }).toThrowError(CollateralizerAdapterErrors.GRACE_PERIOD_EXCEEDS_MAXIMUM());
             });
         });
         describe("...with grace period containing decimals", () => {
@@ -176,7 +176,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                         ...scenario_1.unpackedParams,
                         gracePeriodInDays: new BigNumber(1.567),
                     });
-                }).toThrowError(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+                }).toThrowError(CollateralizerAdapterErrors.INVALID_DECIMAL_VALUE());
             });
         });
         describe("...with valid collateral token index, collateral amount, and grace period in days", () => {
@@ -541,7 +541,7 @@ describe("Collateralized Simple Interest Loan Adapter (Unit Tests)", () => {
                             "0x010000003635c9adc5dea000000003e8300020200000008ac7230489e800005a",
                     }),
                 ).rejects.toThrow(
-                    CollateralizedAdapterErrors.MISMATCHED_TOKEN_SYMBOL(
+                    CollateralizerAdapterErrors.MISMATCHED_TOKEN_SYMBOL(
                         scenario_1.debtOrder.principalToken,
                         MKR_TOKEN_SYMBOL,
                     ),
@@ -627,7 +627,7 @@ describe("Collateralized Simple Interest Loan Adapter (Unit Tests)", () => {
                         termsContract: INVALID_ADDRESS,
                     }),
                 ).rejects.toThrow(
-                    CollateralizedAdapterErrors.MISMATCHED_TERMS_CONTRACT(INVALID_ADDRESS),
+                    CollateralizerAdapterErrors.MISMATCHED_TERMS_CONTRACT(INVALID_ADDRESS),
                 );
             });
         });

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -9,8 +9,6 @@ import { Assertions } from "src/invariants";
 import { DebtOrder, DebtRegistryEntry, RepaymentSchedule } from "src/types";
 import { Adapter } from "./adapter";
 
-import { NULL_ADDRESS } from "../../utils/constants";
-
 import { TermsContractParameters } from "./terms_contract_parameters";
 import {
     SimpleInterestLoanTerms,

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -9,6 +9,8 @@ import { Assertions } from "src/invariants";
 import { DebtOrder, DebtRegistryEntry, RepaymentSchedule } from "src/types";
 import { Adapter } from "./adapter";
 
+import { NULL_ADDRESS } from "../../utils/constants";
+
 import { TermsContractParameters } from "./terms_contract_parameters";
 import {
     SimpleInterestLoanTerms,
@@ -37,7 +39,7 @@ interface CollateralizedSimpleInterestTermsContractParameters
     extends SimpleInterestTermsContractParameters,
         CollateralizedTermsContractParameters {}
 
-export const CollateralizedAdapterErrors = {
+export const CollateralizerAdapterErrors = {
     INVALID_TOKEN_INDEX: (tokenIndex: BigNumber) =>
         singleLineString`Token Registry does not track a token at index
                          ${tokenIndex.toString()}.`,
@@ -103,43 +105,43 @@ export class CollateralizedLoanTerms {
     private assertCollateralTokenIndexWithinBounds(collateralTokenIndex: BigNumber) {
         // Collateral token index cannot be a decimal value.
         if (TermsContractParameters.isDecimalValue(collateralTokenIndex)) {
-            throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+            throw new Error(CollateralizerAdapterErrors.INVALID_DECIMAL_VALUE());
         }
 
         if (collateralTokenIndex.lt(0) || collateralTokenIndex.gt(MAX_COLLATERAL_TOKEN_INDEX_HEX)) {
-            throw new Error(CollateralizedAdapterErrors.INVALID_TOKEN_INDEX(collateralTokenIndex));
+            throw new Error(CollateralizerAdapterErrors.INVALID_TOKEN_INDEX(collateralTokenIndex));
         }
     }
 
     private assertCollateralAmountWithinBounds(collateralAmount: BigNumber) {
         // Collateral amount cannot be a decimal value.
         if (TermsContractParameters.isDecimalValue(collateralAmount)) {
-            throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+            throw new Error(CollateralizerAdapterErrors.INVALID_DECIMAL_VALUE());
         }
 
         if (collateralAmount.lt(0)) {
-            throw new Error(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
+            throw new Error(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
         }
 
         if (collateralAmount.gt(MAX_COLLATERAL_AMOUNT_HEX)) {
-            throw new Error(CollateralizedAdapterErrors.COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM());
+            throw new Error(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM());
         }
     }
 
     private assertGracePeriodInDaysWithinBounds(gracePeriodInDays: BigNumber) {
         // Grace period cannot be a decimal value.
         if (TermsContractParameters.isDecimalValue(gracePeriodInDays)) {
-            throw new Error(CollateralizedAdapterErrors.INVALID_DECIMAL_VALUE());
+            throw new Error(CollateralizerAdapterErrors.INVALID_DECIMAL_VALUE());
         }
 
         // Grace period can't be negative.
         if (gracePeriodInDays.lt(0)) {
-            throw new Error(CollateralizedAdapterErrors.GRACE_PERIOD_IS_NEGATIVE());
+            throw new Error(CollateralizerAdapterErrors.GRACE_PERIOD_IS_NEGATIVE());
         }
 
         // Grace period has a maximum value that cannot be exceeded due to how we pack params.
         if (gracePeriodInDays.gt(MAX_GRACE_PERIOD_IN_DAYS_HEX)) {
-            throw new Error(CollateralizedAdapterErrors.GRACE_PERIOD_EXCEEDS_MAXIMUM());
+            throw new Error(CollateralizerAdapterErrors.GRACE_PERIOD_EXCEEDS_MAXIMUM());
         }
     }
 }
@@ -324,7 +326,7 @@ export class CollateralizedSimpleInterestLoanAdapter implements Adapter.Interfac
 
         if (!doesTokenCorrespondToSymbol) {
             throw new Error(
-                CollateralizedAdapterErrors.MISMATCHED_TOKEN_SYMBOL(tokenAddress, symbol),
+                CollateralizerAdapterErrors.MISMATCHED_TOKEN_SYMBOL(tokenAddress, symbol),
             );
         }
     }
@@ -336,7 +338,7 @@ export class CollateralizedSimpleInterestLoanAdapter implements Adapter.Interfac
 
         if (termsContractAddress !== collateralizedSimpleInterestTermsContract.address) {
             throw new Error(
-                CollateralizedAdapterErrors.MISMATCHED_TERMS_CONTRACT(termsContractAddress),
+                CollateralizerAdapterErrors.MISMATCHED_TERMS_CONTRACT(termsContractAddress),
             );
         }
     }


### PR DESCRIPTION
Just renaming a variable here, but it should be pulled into its own file too. Later.