### PR TITLE
feat: add assertion that a certain account is not the sender

### DIFF
--- a/src/invariants/account.ts
+++ b/src/invariants/account.ts
@@ -1,8 +1,15 @@
 import { NULL_ADDRESS } from "../../utils/constants";
+import { TxData } from "../types";
 
 export class AccountAssertions {
     public notNull(account: string, errorMessage: string) {
         if (account === NULL_ADDRESS) {
+            throw new Error(errorMessage);
+        }
+    }
+
+    public notSender(account: string, txOptions: TxData, errorMessage: string) {
+        if (account === txOptions.from) {
             throw new Error(errorMessage);
         }
     }


### PR DESCRIPTION
This PR introduces the following changes:

- Create an assertion that, given an account and a `TxData` type, throws if the sender of the transaction matches the account. 