### PR TITLE
build: Bump contracts to 0.0.28 and resolve build issues

### DIFF
--- a/__test__/unit/debt_token_wrapper.spec.ts
+++ b/__test__/unit/debt_token_wrapper.spec.ts
@@ -2,7 +2,7 @@ jest.mock("@dharmaprotocol/contracts");
 
 import * as promisify from "tiny-promisify";
 import * as Web3 from "web3";
-import { BigNumber } from "bignumber.js";
+
 // We use an unmocked version of "fs" in order to pull the correct
 // contract address from our artifacts for testing purposes
 import * as fs from "fs";

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "webpack": "^3.11.0"
     },
     "dependencies": {
-        "@dharmaprotocol/contracts": "0.0.27",
+        "@dharmaprotocol/contracts": "0.0.28",
         "@types/lodash": "^4.14.104",
         "abi-decoder": "https://github.com/dharmaprotocol/abi-decoder",
         "bignumber.js": "^5.0.0",

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -2,11 +2,11 @@ import * as Web3 from "web3";
 import * as singleLineString from "single-line-string";
 import * as omit from "lodash.omit";
 
-import { BigNumber } from "utils/bignumber";
+import { BigNumber } from "../../utils/bignumber";
 
-import { ContractsAPI } from "src/apis";
-import { Assertions } from "src/invariants";
-import { DebtOrder, DebtRegistryEntry, RepaymentSchedule } from "src/types";
+import { ContractsAPI } from "../apis";
+import { Assertions } from "../invariants";
+import { DebtOrder, DebtRegistryEntry, RepaymentSchedule } from "../types";
 import { Adapter } from "./adapter";
 
 import { TermsContractParameters } from "./terms_contract_parameters";

--- a/src/adapters/terms_contract_parameters.ts
+++ b/src/adapters/terms_contract_parameters.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "utils/bignumber";
+import { BigNumber } from "../../utils/bignumber";
 
 export namespace TermsContractParameters {
     export function generateHexValueOfLength(length: number): string {

--- a/src/apis/adapters_api.ts
+++ b/src/apis/adapters_api.ts
@@ -16,7 +16,7 @@ import {
 import {
     SimpleInterestTermsContractContract,
     CollateralizedSimpleInterestTermsContractContract,
-} from "src/wrappers";
+} from "../wrappers";
 
 export const AdaptersErrors = {
     NO_ADAPTER_FOR_TERMS_CONTRACT: (termsContractAddress: string) =>

--- a/src/invariants/index.ts
+++ b/src/invariants/index.ts
@@ -32,6 +32,6 @@ export class Assertions {
         this.order = new OrderAssertions(this.contracts);
         this.token = new TokenAssertions();
         this.schema = new SchemaAssertions();
-        this.debtAgreement = new DebtAgreementAssertions(this.web3);
+        this.debtAgreement = new DebtAgreementAssertions();
     }
 }

--- a/src/wrappers/contract_wrappers/debt_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_token_wrapper.ts
@@ -560,7 +560,7 @@ export class DebtTokenContract extends BaseContract {
             return abiEncodedTransactionData;
         },
     };
-    public safeTransferFrom = {
+    public safeTransferFromWithData = {
         async sendTransactionAsync(
             _from: string,
             _to: string,

--- a/src/wrappers/contract_wrappers/debt_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_token_wrapper.ts
@@ -189,49 +189,6 @@ export class DebtTokenContract extends BaseContract {
             return abiEncodedTransactionData;
         },
     };
-    public safeTransferFrom = {
-        async sendTransactionAsync(
-            _from: string,
-            _to: string,
-            _tokenId: BigNumber,
-            txData: TxData = {},
-        ): Promise<string> {
-            const self = this as DebtTokenContract;
-            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
-                txData,
-                self.safeTransferFrom.estimateGasAsync.bind(self, _from, _to, _tokenId),
-            );
-            const txHash = await promisify<string>(
-                self.web3ContractInstance.safeTransferFrom,
-                self.web3ContractInstance,
-            )(_from, _to, _tokenId, txDataWithDefaults);
-            return txHash;
-        },
-        async estimateGasAsync(
-            _from: string,
-            _to: string,
-            _tokenId: BigNumber,
-            txData: TxData = {},
-        ): Promise<number> {
-            const self = this as DebtTokenContract;
-            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
-            const gas = await promisify<number>(
-                self.web3ContractInstance.safeTransferFrom.estimateGas,
-                self.web3ContractInstance,
-            )(_from, _to, _tokenId, txDataWithDefaults);
-            return gas;
-        },
-        getABIEncodedTransactionData(
-            _from: string,
-            _to: string,
-            _tokenId: BigNumber,
-            txData: TxData = {},
-        ): string {
-            const self = this as DebtTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.safeTransferFrom.getData();
-            return abiEncodedTransactionData;
-        },
-    };
     public exists = {
         async callAsync(_tokenId: BigNumber, defaultBlock?: Web3.BlockParam): Promise<boolean> {
             const self = this as DebtTokenContract;
@@ -560,12 +517,12 @@ export class DebtTokenContract extends BaseContract {
             return abiEncodedTransactionData;
         },
     };
-    public safeTransferFromWithData = {
+    public safeTransferFrom = {
         async sendTransactionAsync(
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            _data: string,
+            _data: string = "",
             txData: TxData = {},
         ): Promise<string> {
             const self = this as DebtTokenContract;

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,9 +132,9 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dharmaprotocol/contracts@0.0.27":
-  version "0.0.27"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.27.tgz#5015879e5e96d2eb2748ef37661f581d2978da42"
+"@dharmaprotocol/contracts@0.0.28":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.28.tgz#b19a2a37eee62d59b66403c044e0dd1411dead4e"
   dependencies:
     zeppelin-solidity "^1.8.0"
 


### PR DESCRIPTION
This PR introduces the following changes:

- Bump `@dharmaprotocol/contracts` to 0.0.28
- Resolve various build issues throwing typescript errors.