### PR TITLE
feat: add canBeTransferredByAccount invariant

### DIFF
--- a/src/invariants/debt_token.ts
+++ b/src/invariants/debt_token.ts
@@ -14,7 +14,7 @@ export class DebtTokenAssertions {
         }
     }
 
-    public async tokenBelongsToAccount(
+    public async belongsToAccount(
         debtTokenContract: DebtTokenContract,
         tokenID: BigNumber,
         account: string,
@@ -26,6 +26,30 @@ export class DebtTokenAssertions {
             const tokenOwner = await debtTokenContract.ownerOf.callAsync(tokenID);
 
             if (tokenOwner !== account) {
+                throw new Error(errorMessage);
+            }
+        } catch (e) {
+            throw new Error(errorMessage);
+        }
+    }
+
+    public async canBeTransferredByAccount(
+        debtTokenContract: DebtTokenContract,
+        tokenID: BigNumber,
+        account: string,
+        errorMessage: string,
+    ): Promise<void> {
+        // We include a try-catch here because the Zeppelin 721 implementation
+        // reverts on `ownerOf` if the token's owner is NULL_ADDRESS
+        try {
+            const tokenOwner = await debtTokenContract.ownerOf.callAsync(tokenID);
+            const tokensApprovedAddress = await debtTokenContract.getApproved.callAsync(tokenID);
+            const isApprovedForAll = await debtTokenContract.isApprovedForAll.callAsync(
+                tokenOwner,
+                account,
+            );
+
+            if (tokenOwner !== account && tokensApprovedAddress !== account && !isApprovedForAll) {
                 throw new Error(errorMessage);
             }
         } catch (e) {


### PR DESCRIPTION
This PR introduces the following changes:

- Change `tokenBelongsToAccounts` => `belongsToAccount`
- Add `canBeTransferredByAccont` invariant