### PR TITLE
build: bump contracts to 0.0.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "webpack": "^3.11.0"
     },
     "dependencies": {
-        "@dharmaprotocol/contracts": "0.0.28",
+        "@dharmaprotocol/contracts": "0.0.29",
         "@types/lodash": "^4.14.104",
         "abi-decoder": "https://github.com/dharmaprotocol/abi-decoder",
         "bignumber.js": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,9 +132,9 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dharmaprotocol/contracts@0.0.28":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.28.tgz#b19a2a37eee62d59b66403c044e0dd1411dead4e"
+"@dharmaprotocol/contracts@0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.29.tgz#45b1c8f2ab0c2c0a583c86ac4d53e483c6166941"
   dependencies:
     zeppelin-solidity "^1.8.0"
 


### PR DESCRIPTION
This PR introduces the following changes:

- Bumps the contracts to version 0.0.29