### PR TITLE
refactor: extract runners into separate files

### DIFF
--- a/__test__/integration/debt_token_api/debt_token_api.spec.ts
+++ b/__test__/integration/debt_token_api/debt_token_api.spec.ts
@@ -16,10 +16,6 @@ const web3 = new Web3(provider);
 const scenarioRunner = new DebtTokenScenarioRunner(web3);
 
 describe("Debt Token API (Integration Tests)", () => {
-    beforeAll(async () => {
-        await scenarioRunner.configure();
-    });
-
     beforeEach(scenarioRunner.saveSnapshotAsync);
 
     afterEach(scenarioRunner.revertToSavedSnapshot);

--- a/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
+++ b/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
@@ -1,117 +1,71 @@
+// External
 import * as Web3 from "web3";
-import { Web3Utils } from "utils/web3_utils";
-import { BigNumber } from "bignumber.js";
-import { ERC20TokenSymbol } from "utils/constants";
 
-import { ContractsAPI, DebtTokenAPI, OrderAPI, SignerAPI } from "src/apis/";
+// Scenario Runners
+import { BalanceOfScenarioRunner, TestAPIs, TestAdapters } from "./runners";
 
-import {
-    DummyTokenContract,
-    TokenTransferProxyContract,
-    TokenRegistryContract,
-} from "src/wrappers";
+// APIs
+import { ContractsAPI, DebtTokenAPI, OrderAPI, SignerAPI, TokenAPI } from "src/apis/";
 
+// Types
 import { DebtTokenScenario } from "./scenarios";
 
+// Adapters
 import { SimpleInterestLoanAdapter } from "src/adapters";
 
-import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
-
-import { ACCOUNTS } from "../../accounts";
-
-const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
+// Utils
+import { Web3Utils } from "utils/web3_utils";
 
 export class DebtTokenScenarioRunner {
     private web3Utils: Web3Utils;
     private web3: Web3;
-
-    // Contracts
-    private tokenTransferProxy: TokenTransferProxyContract;
-    private tokenRegistry: TokenRegistryContract;
-
     // APIs
-    private contractsAPI: ContractsAPI;
-    private debtTokenAPI: DebtTokenAPI;
-    private orderAPI: OrderAPI;
-    private signerAPI: SignerAPI;
+    private testAPIs: TestAPIs;
 
     // Adapters
-    private simpleInterestLoanAdapter: SimpleInterestLoanAdapter;
+    private testAdapters: TestAdapters;
 
-    private isConfigured: boolean = false;
+    // Scenario Runners
+    private balanceOfScenarioRunner: BalanceOfScenarioRunner;
+
     private currentSnapshotId: number;
 
     constructor(web3: Web3) {
         this.web3 = web3;
         this.web3Utils = new Web3Utils(web3);
 
+        const contractsAPI = new ContractsAPI(this.web3);
+        const debtTokenAPI = new DebtTokenAPI(this.web3, contractsAPI);
+        const tokenAPI = new TokenAPI(this.web3, contractsAPI);
+        const orderAPI = new OrderAPI(this.web3, contractsAPI);
+        const signerAPI = new SignerAPI(this.web3, contractsAPI);
+        this.testAPIs = {
+            contractsAPI,
+            debtTokenAPI,
+            orderAPI,
+            signerAPI,
+            tokenAPI,
+        };
+
+        // Adapters
+        this.testAdapters = {
+            simpleInterestLoanAdapter: new SimpleInterestLoanAdapter(contractsAPI),
+        };
+
+        this.balanceOfScenarioRunner = new BalanceOfScenarioRunner();
+
         this.testBalanceOfScenario = this.testBalanceOfScenario.bind(this);
         this.saveSnapshotAsync = this.saveSnapshotAsync.bind(this);
         this.revertToSavedSnapshot = this.revertToSavedSnapshot.bind(this);
     }
 
-    public async configure() {
-        // Prevent unnecessary configuration.
-        if (this.isConfigured) {
-            return;
-        }
-
-        // APIs
-        this.contractsAPI = new ContractsAPI(this.web3);
-        this.debtTokenAPI = new DebtTokenAPI(this.web3, this.contractsAPI);
-        this.orderAPI = new OrderAPI(this.web3, this.contractsAPI);
-        this.signerAPI = new SignerAPI(this.web3, this.contractsAPI);
-
-        // Contracts
-        this.tokenTransferProxy = await TokenTransferProxyContract.deployed(this.web3, TX_DEFAULTS);
-        this.tokenRegistry = await TokenRegistryContract.deployed(this.web3, TX_DEFAULTS);
-
-        // Adapters
-        this.simpleInterestLoanAdapter = new SimpleInterestLoanAdapter(this.contractsAPI);
-
-        this.isConfigured = true;
-    }
-
-    private async generateDebtTokenForOrder(order: SimpleInterestLoanOrder) {
-        const principalTokenAddress = await this.tokenRegistry.getTokenAddressBySymbol.callAsync(
-            order.principalTokenSymbol,
-        );
-
-        const principalToken = await DummyTokenContract.at(
-            principalTokenAddress,
-            this.web3,
-            TX_DEFAULTS,
-        );
-
-        await principalToken.setBalance.sendTransactionAsync(order.creditor, order.principalAmount);
-
-        await principalToken.approve.sendTransactionAsync(
-            this.tokenTransferProxy.address,
-            order.principalAmount,
-            { from: order.creditor },
-        );
-
-        order = await this.orderAPI.generate(this.simpleInterestLoanAdapter, order);
-        order.debtorSignature = await this.signerAPI.asDebtor(order, false);
-
-        await this.orderAPI.fillAsync(order, {
-            from: order.creditor,
-        });
-    }
-
     public async testBalanceOfScenario(scenario: DebtTokenScenario.BalanceOfScenario) {
-        describe(scenario.description, () => {
-            beforeEach(async () => {
-                for (let order of scenario.orders) {
-                    await this.generateDebtTokenForOrder(order);
-                }
-            });
-
-            test("returns correct balance of debt tokens", async () => {
-                const computedBalance = await this.debtTokenAPI.balanceOf(scenario.creditor);
-                await expect(computedBalance.toNumber()).toEqual(scenario.balance);
-            });
-        });
+        return this.balanceOfScenarioRunner.testScenario(
+            scenario,
+            this.web3,
+            this.testAPIs,
+            this.testAdapters,
+        );
     }
 
     public async saveSnapshotAsync() {

--- a/__test__/integration/debt_token_api/runners/balance_of.ts
+++ b/__test__/integration/debt_token_api/runners/balance_of.ts
@@ -28,34 +28,4 @@ export class BalanceOfScenarioRunner extends ScenarioRunner {
             });
         });
     }
-
-    private async generateDebtTokenForOrder(
-        simpleInterestLoanOrder: SimpleInterestLoanOrder,
-        web3: Web3,
-        testAPIs: TestAPIs,
-        testAdapters: TestAdapters,
-    ) {
-        const { orderAPI, signerAPI, tokenAPI } = testAPIs;
-        const { simpleInterestLoanAdapter } = testAdapters;
-
-        const principalTokenAddress = await this.configureTokenBalance(
-            web3,
-            testAPIs,
-            simpleInterestLoanOrder.creditor,
-            simpleInterestLoanOrder.principalAmount,
-            simpleInterestLoanOrder.principalTokenSymbol,
-        );
-
-        await tokenAPI.setProxyAllowanceAsync(
-            principalTokenAddress,
-            simpleInterestLoanOrder.principalAmount,
-        );
-
-        const order = await orderAPI.generate(simpleInterestLoanAdapter, simpleInterestLoanOrder);
-        order.debtorSignature = await signerAPI.asDebtor(order, false);
-
-        await orderAPI.fillAsync(order, {
-            from: order.creditor,
-        });
-    }
 }

--- a/__test__/integration/debt_token_api/runners/balance_of.ts
+++ b/__test__/integration/debt_token_api/runners/balance_of.ts
@@ -1,0 +1,61 @@
+// External
+import * as Web3 from "web3";
+
+// Types
+import { ScenarioRunner, TestAPIs, TestAdapters } from "./";
+import { DebtTokenScenario } from "../scenarios";
+import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
+
+export class BalanceOfScenarioRunner extends ScenarioRunner {
+    public testScenario(
+        scenario: DebtTokenScenario.BalanceOfScenario,
+        web3: Web3,
+        testAPIs: TestAPIs,
+        testAdapters: TestAdapters,
+    ) {
+        const { debtTokenAPI } = testAPIs;
+
+        describe(scenario.description, () => {
+            beforeEach(async () => {
+                for (let order of scenario.orders) {
+                    await this.generateDebtTokenForOrder(order, web3, testAPIs, testAdapters);
+                }
+            });
+
+            test("returns correct balance of debt tokens", async () => {
+                const computedBalance = await debtTokenAPI.balanceOf(scenario.creditor);
+                expect(computedBalance.toNumber()).toEqual(scenario.balance);
+            });
+        });
+    }
+
+    private async generateDebtTokenForOrder(
+        simpleInterestLoanOrder: SimpleInterestLoanOrder,
+        web3: Web3,
+        testAPIs: TestAPIs,
+        testAdapters: TestAdapters,
+    ) {
+        const { orderAPI, signerAPI, tokenAPI } = testAPIs;
+        const { simpleInterestLoanAdapter } = testAdapters;
+
+        const principalTokenAddress = await this.configureTokenBalance(
+            web3,
+            testAPIs,
+            simpleInterestLoanOrder.creditor,
+            simpleInterestLoanOrder.principalAmount,
+            simpleInterestLoanOrder.principalTokenSymbol,
+        );
+
+        await tokenAPI.setProxyAllowanceAsync(
+            principalTokenAddress,
+            simpleInterestLoanOrder.principalAmount,
+        );
+
+        const order = await orderAPI.generate(simpleInterestLoanAdapter, simpleInterestLoanOrder);
+        order.debtorSignature = await signerAPI.asDebtor(order, false);
+
+        await orderAPI.fillAsync(order, {
+            from: order.creditor,
+        });
+    }
+}

--- a/__test__/integration/debt_token_api/runners/index.ts
+++ b/__test__/integration/debt_token_api/runners/index.ts
@@ -1,0 +1,61 @@
+// External
+import { BigNumber } from "bignumber.js";
+import * as Web3 from "web3";
+
+// Types
+import { DebtTokenScenario } from "../scenarios";
+
+// APIs
+import { ContractsAPI, DebtTokenAPI, OrderAPI, SignerAPI, TokenAPI } from "src/apis";
+
+// Adapters
+import { SimpleInterestLoanAdapter } from "src/adapters";
+
+// Wrappers
+import { DummyTokenContract } from "src/wrappers";
+
+// Utils
+import { ACCOUNTS } from "../../../accounts";
+
+const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
+
+export interface TestAPIs {
+    contractsAPI: ContractsAPI;
+    debtTokenAPI: DebtTokenAPI;
+    orderAPI: OrderAPI;
+    signerAPI: SignerAPI;
+    tokenAPI: TokenAPI;
+}
+
+export interface TestAdapters {
+    simpleInterestLoanAdapter: SimpleInterestLoanAdapter;
+}
+
+export abstract class ScenarioRunner {
+    public abstract testScenario(
+        scenario: DebtTokenScenario.Scenario,
+        web3: Web3,
+        testAPIs: TestAPIs,
+        testAdapters: TestAdapters,
+    ): void;
+
+    public async configureTokenBalance(
+        web3: Web3,
+        testAPIs: TestAPIs,
+        account: string,
+        balance: BigNumber,
+        tokenSymbol: string,
+    ): Promise<string> {
+        const { contractsAPI } = testAPIs;
+
+        const tokenAddress = await contractsAPI.getTokenAddressBySymbolAsync(tokenSymbol);
+
+        const dummyToken = await DummyTokenContract.at(tokenAddress, web3, TX_DEFAULTS);
+
+        await dummyToken.setBalance.sendTransactionAsync(account, balance);
+
+        return tokenAddress;
+    }
+}
+
+export { BalanceOfScenarioRunner } from "./balance_of";

--- a/__test__/integration/debt_token_api/runners/index.ts
+++ b/__test__/integration/debt_token_api/runners/index.ts
@@ -4,6 +4,7 @@ import * as Web3 from "web3";
 
 // Types
 import { DebtTokenScenario } from "../scenarios";
+import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
 
 // APIs
 import { ContractsAPI, DebtTokenAPI, OrderAPI, SignerAPI, TokenAPI } from "src/apis";
@@ -39,7 +40,37 @@ export abstract class ScenarioRunner {
         testAdapters: TestAdapters,
     ): void;
 
-    public async configureTokenBalance(
+    public async generateDebtTokenForOrder(
+        simpleInterestLoanOrder: SimpleInterestLoanOrder,
+        web3: Web3,
+        testAPIs: TestAPIs,
+        testAdapters: TestAdapters,
+    ) {
+        const { orderAPI, signerAPI, tokenAPI } = testAPIs;
+        const { simpleInterestLoanAdapter } = testAdapters;
+
+        const principalTokenAddress = await this.configureTokenBalance(
+            web3,
+            testAPIs,
+            simpleInterestLoanOrder.creditor,
+            simpleInterestLoanOrder.principalAmount,
+            simpleInterestLoanOrder.principalTokenSymbol,
+        );
+
+        await tokenAPI.setProxyAllowanceAsync(
+            principalTokenAddress,
+            simpleInterestLoanOrder.principalAmount,
+        );
+
+        const order = await orderAPI.generate(simpleInterestLoanAdapter, simpleInterestLoanOrder);
+        order.debtorSignature = await signerAPI.asDebtor(order, false);
+
+        await orderAPI.fillAsync(order, {
+            from: order.creditor,
+        });
+    }
+
+    private async configureTokenBalance(
         web3: Web3,
         testAPIs: TestAPIs,
         account: string,

--- a/__test__/integration/debt_token_api/scenarios/balance_of.ts
+++ b/__test__/integration/debt_token_api/scenarios/balance_of.ts
@@ -41,7 +41,9 @@ const order3: SimpleInterestLoanOrder = {
 const ORDERS = [order1, order2, order3];
 
 const DESCRIPTION = (balance: number) =>
-    singleLineString`when user holds a balance of ${balance} debt token${balance == 1 ? "" : "s"}.`;
+    singleLineString`when user holds a balance of ${balance} debt token${
+        balance === 1 ? "" : "s"
+    }.`;
 
 function generateScenarioForBalanceOf(balance: number): DebtTokenScenario.BalanceOfScenario {
     return {

--- a/__test__/integration/debt_token_api/scenarios/scenarios.ts
+++ b/__test__/integration/debt_token_api/scenarios/scenarios.ts
@@ -1,4 +1,6 @@
 import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
+import { BigNumber } from "bignumber.js";
+import { TxData } from "src/types";
 
 export namespace DebtTokenScenario {
     export interface Scenario {
@@ -10,5 +12,13 @@ export namespace DebtTokenScenario {
 
     export interface BalanceOfScenario extends Scenario {
         balance: number;
+    }
+
+    export interface TransferFromScenario extends Scenario {
+        from: string;
+        to: string;
+        tokenID: BigNumber;
+        data?: string;
+        options?: TxData;
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- For readability / preventing file bloat, I've extracted the runners in `DebtTokenScenarioRunner` into separate files that inherit from the same `ScenarioRunner` base class.  I think this will pay dividends in cleanliness as we add test scenarios to the file.