### PR TITLE
fix: bignumber.js formatting issue

### DIFF
--- a/src/invariants/order.ts
+++ b/src/invariants/order.ts
@@ -52,8 +52,8 @@ export class OrderAssertions {
 
     // creditorFee + debtorFee == relayerFee + underwriterFee
     public validFees(debtOrder: DebtOrder.Instance, errorMessage: string) {
-        const feesContributed = debtOrder.creditorFee.add(debtOrder.debtorFee);
-        const feesDistributed = debtOrder.relayerFee.add(debtOrder.underwriterFee);
+        const feesContributed = debtOrder.creditorFee.plus(debtOrder.debtorFee);
+        const feesDistributed = debtOrder.relayerFee.plus(debtOrder.underwriterFee);
         if (!feesContributed.eq(feesDistributed)) {
             throw new Error(errorMessage);
         }
@@ -224,7 +224,7 @@ export class OrderAssertions {
         errorMessage: string,
     ) {
         const creditorBalance = await principalToken.balanceOf.callAsync(debtOrder.creditor);
-        if (creditorBalance.lt(debtOrder.principalAmount.add(debtOrder.creditorFee))) {
+        if (creditorBalance.lt(debtOrder.principalAmount.plus(debtOrder.creditorFee))) {
             throw new Error(errorMessage);
         }
     }
@@ -241,7 +241,7 @@ export class OrderAssertions {
             tokenTransferProxy.address,
         );
 
-        if (creditorAllowance.lt(debtOrder.principalAmount.add(debtOrder.creditorFee))) {
+        if (creditorAllowance.lt(debtOrder.principalAmount.plus(debtOrder.creditorFee))) {
             throw new Error(errorMessage);
         }
     }

--- a/src/schemas/basic_type_schemas.ts
+++ b/src/schemas/basic_type_schemas.ts
@@ -13,10 +13,7 @@ export const bytes32Schema = {
 export const numberSchema = {
     id: "/Number",
     type: "object",
-    properties: {
-        isBigNumber: { type: "boolean" },
-    },
-    required: ["isBigNumber"],
+    // Ensures that the object meets the validator.customFormats.BigNumber format.
     format: "BigNumber",
 };
 

--- a/src/schemas/custom_formats.ts
+++ b/src/schemas/custom_formats.ts
@@ -1,13 +1,33 @@
+import { BigNumber } from "bignumber.js";
 // NOTE: The input's format only matters if the input is required (since, if an input
 // is required by the schema but undefined, the validator will throw an error at another point.)
 // Hence, we can skip validating format if the input is undefined.
 
 export const bigNumberFormat = function(input) {
     const regex = RegExp("^\\d+(\\.\\d+)?$");
-    return input === undefined || (input.isBigNumber && regex.test(input.toString()));
+
+    return input === undefined || (isBigNumber(input) && regex.test(input.toString()));
 };
 
 export const wholeBigNumberFormat = function(input) {
     const regex = RegExp("^\\d+$");
     return input === undefined || (input.isBigNumber && regex.test(input.toString()));
 };
+
+/**
+ * NOTE: BigNumber.js is currently changing their API, and isBigNumber is deprecated (I.E. not
+ * available in version 6.0. However, Truffe.js uses version 5.0, and the breaking changes between
+ * versions are such that we have to keep using 5.0 until Truffle upgrades.
+ *
+ * In version 6.0, this can be replaced with `BigNumber.isBigNumber(object);`
+ *
+ * @param object
+ * @returns {boolean}
+ */
+function isBigNumber(object: any): boolean {
+    return (
+        object.isBigNumber ||
+        object instanceof BigNumber ||
+        (object.constructor && object.constructor.name === "BigNumber")
+    );
+}

--- a/src/schemas/custom_formats.ts
+++ b/src/schemas/custom_formats.ts
@@ -15,9 +15,10 @@ export const wholeBigNumberFormat = function(input) {
 };
 
 /**
- * NOTE: BigNumber.js is currently changing their API, and isBigNumber is deprecated (I.E. not
- * available in version 6.0. However, Truffe.js uses version 5.0, and the breaking changes between
- * versions are such that we have to keep using 5.0 until Truffle upgrades.
+ * NOTE: BigNumber.js is currently changing their API, and the method `isBigNumber` on instances
+ * of BigNumber is deprecated. I.E. this will not be available in the next version (v6.0.)
+ *
+ * However, Truffe.js uses v5.0, and so we are dependent on v5.0 until Truffle upgrades.
  *
  * In version 6.0, this can be replaced with `BigNumber.isBigNumber(object);`
  *


### PR DESCRIPTION
Note: `.add` is deprecated, as is `isBigNumber` on the instance. Dependency on Truffle.js means we cannot upgrade BigNumber.js at this time.