### PR TITLE
Add ERC721 Receiver Wrappers

### DIFF
--- a/__test__/integration/debt_token_api/debt_token_api.spec.ts
+++ b/__test__/integration/debt_token_api/debt_token_api.spec.ts
@@ -8,7 +8,13 @@ import * as Web3 from "web3";
 
 import { DebtTokenScenarioRunner } from "./debt_token_scenario_runner";
 
-import { BALANCE_OF_SCENARIOS, OWNER_OF_SCENARIOS, EXISTS_SCENARIOS } from "./scenarios";
+import {
+    BALANCE_OF_SCENARIOS,
+    OWNER_OF_SCENARIOS,
+    EXISTS_SCENARIOS,
+    SUCCESSFUL_TRANSFER_FROM_SCENARIOS,
+    UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS,
+} from "./scenarios";
 
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
@@ -16,9 +22,13 @@ const web3 = new Web3(provider);
 const scenarioRunner = new DebtTokenScenarioRunner(web3);
 
 describe("Debt Token API (Integration Tests)", () => {
-    beforeEach(scenarioRunner.saveSnapshotAsync);
+    beforeEach(() => {
+        return scenarioRunner.saveSnapshotAsync();
+    });
 
-    afterEach(scenarioRunner.revertToSavedSnapshot);
+    afterEach(() => {
+        return scenarioRunner.revertToSavedSnapshot();
+    });
 
     describe("#balanceOf", () => {
         describe("debt token balances should be retrievable", () => {
@@ -35,6 +45,16 @@ describe("Debt Token API (Integration Tests)", () => {
     describe("#exists", () => {
         describe("the existence of a given debt token id should be confirmable", () => {
             EXISTS_SCENARIOS.forEach(scenarioRunner.testExistsScenario);
+        });
+    });
+
+    describe("#transferFrom", () => {
+        describe("should fail", () => {
+            UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS.forEach(scenarioRunner.testTransferFromScenario);
+        });
+
+        describe("should succeed", () => {
+            SUCCESSFUL_TRANSFER_FROM_SCENARIOS.forEach(scenarioRunner.testTransferFromScenario);
         });
     });
 });

--- a/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
+++ b/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
@@ -6,8 +6,7 @@ import {
     OwnerOfScenarioRunner,
     BalanceOfScenarioRunner,
     ExistsScenarioRunner,
-    TestAPIs,
-    TestAdapters,
+    TransferFromScenarioRunner,
 } from "./runners";
 
 // APIs
@@ -25,12 +24,14 @@ import { Web3Utils } from "utils/web3_utils";
 export class DebtTokenScenarioRunner {
     // Snapshotting.
     private web3Utils: Web3Utils;
+
     private currentSnapshotId: number;
 
     // Scenario Runners
     private balanceOfScenarioRunner: BalanceOfScenarioRunner;
     private ownerOfScenarioRunner: OwnerOfScenarioRunner;
     private existsScenarioRunner: ExistsScenarioRunner;
+    private transferFromScenarioRunner: TransferFromScenarioRunner;
 
     constructor(web3: Web3) {
         this.web3Utils = new Web3Utils(web3);
@@ -56,10 +57,16 @@ export class DebtTokenScenarioRunner {
         this.balanceOfScenarioRunner = new BalanceOfScenarioRunner(web3, testAPIs, testAdapters);
         this.ownerOfScenarioRunner = new OwnerOfScenarioRunner(web3, testAPIs, testAdapters);
         this.existsScenarioRunner = new ExistsScenarioRunner(web3, testAPIs, testAdapters);
+        this.transferFromScenarioRunner = new TransferFromScenarioRunner(
+            web3,
+            testAPIs,
+            testAdapters,
+        );
 
         this.testOwnerOfScenario = this.testOwnerOfScenario.bind(this);
         this.testBalanceOfScenario = this.testBalanceOfScenario.bind(this);
         this.testExistsScenario = this.testExistsScenario.bind(this);
+        this.testTransferFromScenario = this.testTransferFromScenario.bind(this);
 
         this.saveSnapshotAsync = this.saveSnapshotAsync.bind(this);
         this.revertToSavedSnapshot = this.revertToSavedSnapshot.bind(this);
@@ -75,6 +82,10 @@ export class DebtTokenScenarioRunner {
 
     public async testExistsScenario(scenario: DebtTokenScenario.ExistsScenario) {
         return this.existsScenarioRunner.testScenario(scenario);
+    }
+
+    public async testTransferFromScenario(scenario: DebtTokenScenario.TransferFromScenario) {
+        return this.transferFromScenarioRunner.testScenario(scenario);
     }
 
     public async saveSnapshotAsync() {

--- a/__test__/integration/debt_token_api/runners/balance_of.ts
+++ b/__test__/integration/debt_token_api/runners/balance_of.ts
@@ -1,6 +1,3 @@
-// External
-import * as Web3 from "web3";
-
 // Types
 import { ScenarioRunner } from "./";
 import { DebtTokenScenario } from "../scenarios";

--- a/__test__/integration/debt_token_api/runners/index.ts
+++ b/__test__/integration/debt_token_api/runners/index.ts
@@ -5,7 +5,6 @@ import * as Web3 from "web3";
 // Types
 import { DebtTokenScenario } from "../scenarios";
 import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
-import { DebtOrder } from "src/types";
 
 // APIs
 import { ContractsAPI, DebtTokenAPI, OrderAPI, SignerAPI, TokenAPI } from "src/apis";
@@ -107,3 +106,4 @@ export abstract class ScenarioRunner {
 export { BalanceOfScenarioRunner } from "./balance_of";
 export { OwnerOfScenarioRunner } from "./owner_of";
 export { ExistsScenarioRunner } from "./exists";
+export { TransferFromScenarioRunner } from "./transfer_from";

--- a/__test__/integration/debt_token_api/runners/transfer_from.ts
+++ b/__test__/integration/debt_token_api/runners/transfer_from.ts
@@ -1,0 +1,142 @@
+// External
+import { BigNumber } from "bignumber.js";
+
+// Types
+import { ScenarioRunner } from "./";
+import { DebtTokenScenario } from "../scenarios";
+
+// Wrappers
+import { MockERC721ReceiverContract, TokenRegistryContract } from "src/wrappers";
+
+// Utils
+import { ACCOUNTS } from "../../../accounts";
+
+const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
+
+export class TransferFromScenarioRunner extends ScenarioRunner {
+    public testScenario(scenario: DebtTokenScenario.TransferFromScenario) {
+        const NONEXISTENT_TOKEN_ID = new BigNumber(13);
+        const USER_RECIPIENT = ACCOUNTS[5].address;
+
+        const NON_CREDITOR_ADDRESS = ACCOUNTS[8].address;
+        const MALFORMED_TOKEN_RECIPIENT = "0x123";
+
+        let scenarioRecipient: string;
+        let recipientIsContract: boolean;
+        let erc721ReceiverContract: MockERC721ReceiverContract;
+
+        const { debtTokenAPI } = this.testAPIs;
+        let scenarioTokenID: BigNumber;
+        let transferFromPromise: Promise<string>;
+
+        describe(scenario.description, () => {
+            beforeEach(async () => {
+                erc721ReceiverContract = await MockERC721ReceiverContract.deployed(
+                    this.web3,
+                    TX_DEFAULTS,
+                );
+                const tokenRegistryContract = await TokenRegistryContract.deployed(
+                    this.web3,
+                    TX_DEFAULTS,
+                );
+
+                // Reset erc721Receiver contract so we can detect whether it's being called
+                await erc721ReceiverContract.reset.sendTransactionAsync();
+
+                // Contracts receiving transfers must implement the wallet interface...
+                const VALID_CONTRACT_RECIPIENT = erc721ReceiverContract.address;
+                // ...which the TokenRegistry contract does not
+                const INVALID_CONTRACT_RECIPIENT = tokenRegistryContract.address;
+
+                scenarioRecipient = scenario.to(
+                    USER_RECIPIENT,
+                    VALID_CONTRACT_RECIPIENT,
+                    INVALID_CONTRACT_RECIPIENT,
+                    MALFORMED_TOKEN_RECIPIENT,
+                );
+
+                const tokenIDs = await Promise.all(
+                    scenario.orders.map(this.generateDebtTokenForOrder),
+                );
+
+                const [creditorsTokenID, nonCreditorsTokenID] = tokenIDs;
+
+                // Transfer nonCreditorsToken to a different address
+                await debtTokenAPI.transferFrom(
+                    scenario.creditor,
+                    NON_CREDITOR_ADDRESS,
+                    nonCreditorsTokenID,
+                    "",
+                    { from: scenario.creditor },
+                );
+
+                // Set token approvals
+                await debtTokenAPI.approve(scenario.tokensApprovedOperator, creditorsTokenID, {
+                    from: scenario.creditor,
+                });
+
+                // Set owner's approvals
+                await debtTokenAPI.setApprovalForAll(scenario.ownersApprovedOperator, true);
+
+                scenarioTokenID = scenario.tokenID(
+                    creditorsTokenID,
+                    nonCreditorsTokenID,
+                    NONEXISTENT_TOKEN_ID,
+                );
+
+                // If the recipient is the MockERC721Recipient contract, we have to budget
+                // more gas to account for fees spent on recording the onERC721Received
+                // mock method call.  If the gas is left unspecified (i.e. null), the
+                // debtToken API will choose a default gas value for transferFrom
+                recipientIsContract =
+                    scenarioRecipient === VALID_CONTRACT_RECIPIENT ||
+                    scenarioRecipient === INVALID_CONTRACT_RECIPIENT;
+
+                // HACK: This is a temporary measure for dealing with discrepancies in gas costs
+                //       for different transferFrom calls (depending on how much gas the recipient contract
+                //       guzzles in the onER721Received method call).  A more permanent solution is tracked
+                //       in this Pivotal story: https://www.pivotaltracker.com/story/show/156644350
+                const transferFromGas = recipientIsContract ? 300000 : 250000;
+
+                transferFromPromise = debtTokenAPI.transferFrom(
+                    scenario.from,
+                    scenarioRecipient,
+                    scenarioTokenID,
+                    scenario.data,
+                    {
+                        from: scenario.sender,
+                        gas: transferFromGas,
+                    },
+                );
+
+                if (scenario.succeeds) {
+                    await transferFromPromise;
+                }
+            });
+
+            if (scenario.succeeds) {
+                test(`token's owner has changed to scenario's recipient`, async () => {
+                    await expect(debtTokenAPI.ownerOf(scenarioTokenID)).resolves.toEqual(
+                        scenarioRecipient,
+                    );
+                });
+
+                test("(if recipient is contract) onERC721Received method was called with correct data", async () => {
+                    if (recipientIsContract) {
+                        await expect(
+                            erc721ReceiverContract.wasOnERC721ReceivedCalledWith.callAsync(
+                                scenario.from,
+                                scenarioTokenID,
+                                scenario.data || "",
+                            ),
+                        ).resolves.toBeTruthy();
+                    }
+                });
+            } else {
+                test(`throws ${scenario.errorType}`, async () => {
+                    await expect(transferFromPromise).rejects.toThrow(scenario.errorMessage);
+                });
+            }
+        });
+    }
+}

--- a/__test__/integration/debt_token_api/scenarios/index.ts
+++ b/__test__/integration/debt_token_api/scenarios/index.ts
@@ -1,6 +1,6 @@
-import { DebtTokenScenario } from "./scenarios";
-import { BALANCE_OF_SCENARIOS } from "./balance_of";
-import { OWNER_OF_SCENARIOS } from "./owner_of";
-import { EXISTS_SCENARIOS } from "./exists";
-
-export { DebtTokenScenario, BALANCE_OF_SCENARIOS, OWNER_OF_SCENARIOS, EXISTS_SCENARIOS };
+export { DebtTokenScenario } from "./scenarios";
+export { BALANCE_OF_SCENARIOS } from "./balance_of";
+export { OWNER_OF_SCENARIOS } from "./owner_of";
+export { EXISTS_SCENARIOS } from "./exists";
+export { UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS } from "./unsuccessful_transfer_from";
+export { SUCCESSFUL_TRANSFER_FROM_SCENARIOS } from "./successful_transfer_from";

--- a/__test__/integration/debt_token_api/scenarios/scenarios.ts
+++ b/__test__/integration/debt_token_api/scenarios/scenarios.ts
@@ -1,6 +1,5 @@
 import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
 import { BigNumber } from "bignumber.js";
-import { TxData } from "src/types";
 
 export namespace DebtTokenScenario {
     export interface Scenario {
@@ -23,10 +22,31 @@ export namespace DebtTokenScenario {
     }
 
     export interface TransferFromScenario extends Scenario {
+        // Setup arguments
+        tokensApprovedOperator: string;
+        ownersApprovedOperator: string;
+
+        // TransferFrom method arguments
         from: string;
-        to: string;
-        tokenID: BigNumber;
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => string;
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            otherTokenId: BigNumber,
+            nonexistentTokenId: BigNumber,
+        ) => BigNumber;
         data?: string;
-        options?: TxData;
+
+        // Transaction options
+        sender: string;
+
+        // Scenario outcome
+        succeeds: boolean;
+        errorType?: string;
+        errorMessage?: string;
     }
 }

--- a/__test__/integration/debt_token_api/scenarios/successful_transfer_from.ts
+++ b/__test__/integration/debt_token_api/scenarios/successful_transfer_from.ts
@@ -1,0 +1,91 @@
+// External
+import { BigNumber } from "bignumber.js";
+
+// Utils
+import { ACCOUNTS } from "../../../accounts";
+import { Orders } from "./orders";
+
+// Types
+import { DebtTokenScenario } from "./";
+
+const TOKENS_APPROVED_OPERATOR = ACCOUNTS[2].address;
+const OWNERS_APPROVED_OPERATOR = ACCOUNTS[3].address;
+
+const defaults = {
+    // Scenario Setup Parameters
+    orders: Orders.ALL_ORDERS,
+    ...Orders.WHO,
+    succeeds: true,
+
+    // TransferFrom Setup Parameters
+    tokensApprovedOperator: TOKENS_APPROVED_OPERATOR,
+    ownersApprovedOperator: OWNERS_APPROVED_OPERATOR,
+
+    // TransferFrom Scenario Parameters
+    from: Orders.CREDITOR,
+    to: (
+        userRecipient: string,
+        validContractRecipient: string,
+        invalidContractRecipient: string,
+        malformed: string,
+    ) => userRecipient,
+    tokenID: (
+        ordersIssuanceHash: BigNumber,
+        otherTokenId: BigNumber,
+        nonexistentTokenId: BigNumber,
+    ) => ordersIssuanceHash,
+    sender: Orders.CREDITOR,
+};
+
+export const SUCCESSFUL_TRANSFER_FROM_SCENARIOS: DebtTokenScenario.TransferFromScenario[] = [
+    {
+        ...defaults,
+        description: "called by tokens owner to a non-contract recipient",
+    },
+    {
+        ...defaults,
+        description:
+            "called by token's approved operator (i.e. `approve`) to a non-contract recipient",
+        sender: TOKENS_APPROVED_OPERATOR,
+    },
+    {
+        ...defaults,
+        description:
+            "called by token owner's approved operator (i.e. `setApprovalForAll`) to a non-contract recipient",
+        sender: OWNERS_APPROVED_OPERATOR,
+    },
+    {
+        ...defaults,
+        description: "called by tokens owner to a valid contract recipient",
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => validContractRecipient,
+    },
+    {
+        ...defaults,
+        description:
+            "called by token's approved operator (i.e. `approve`) to a valid contract recipient",
+        sender: TOKENS_APPROVED_OPERATOR,
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => validContractRecipient,
+    },
+    {
+        ...defaults,
+        description:
+            "called by token owner's approved operator (i.e. `setApprovalForAll`) to a valid contract recipient",
+        sender: OWNERS_APPROVED_OPERATOR,
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => validContractRecipient,
+    },
+];

--- a/__test__/integration/debt_token_api/scenarios/unsuccessful_transfer_from.ts
+++ b/__test__/integration/debt_token_api/scenarios/unsuccessful_transfer_from.ts
@@ -1,0 +1,119 @@
+// External
+import { BigNumber } from "bignumber.js";
+
+// Utils
+import { ACCOUNTS } from "../../../accounts";
+import { Orders } from "./orders";
+
+// Types
+import { DebtTokenScenario } from "./";
+
+// Errors
+import { DebtTokenAPIErrors } from "src/apis/debt_token_api";
+
+const TOKENS_APPROVED_OPERATOR = ACCOUNTS[2].address;
+const OWNERS_APPROVED_OPERATOR = ACCOUNTS[3].address;
+const UNAPPROVED_TRANSFER_FROM_SENDER = ACCOUNTS[4].address;
+
+const defaults: DebtTokenScenario.TransferFromScenario = {
+    // Scenario Setup Parameters
+    description: `Default Description`,
+    orders: Orders.ALL_ORDERS,
+    ...Orders.WHO,
+    succeeds: false,
+
+    // TransferFrom Setup Parameters
+    tokensApprovedOperator: TOKENS_APPROVED_OPERATOR,
+    ownersApprovedOperator: OWNERS_APPROVED_OPERATOR,
+
+    // TransferFrom Scenario parameters
+    from: Orders.CREDITOR,
+    to: (
+        userRecipient: string,
+        validContractRecipient: string,
+        invalidContractRecipient: string,
+        malformed: string,
+    ) => userRecipient,
+    tokenID: (
+        ordersIssuanceHash: BigNumber,
+        otherTokenId: BigNumber,
+        nonExistentTokenId: BigNumber,
+    ) => ordersIssuanceHash,
+    sender: Orders.CREDITOR,
+};
+
+export const UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS: DebtTokenScenario.TransferFromScenario[] = [
+    {
+        ...defaults,
+        description: "debt token does not exist",
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            nonCreditorsTokenID: BigNumber,
+            nonExistentTokenId: BigNumber,
+        ) => nonExistentTokenId,
+        errorType: "TOKEN_DOES_NOT_EXIST",
+        errorMessage: DebtTokenAPIErrors.TOKEN_DOES_NOT_EXIST(new BigNumber(13)),
+    },
+    {
+        ...defaults,
+        description: "account being transferred from does not own debt token",
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            nonCreditorsTokenID: BigNumber,
+            nonExistentTokenId: BigNumber,
+        ) => nonCreditorsTokenID,
+        errorType: "TOKEN_DOES_NOT_BELONG_TO_ACCOUNT",
+        errorMessage: DebtTokenAPIErrors.TOKEN_DOES_NOT_BELONG_TO_ACCOUNT(Orders.CREDITOR),
+    },
+    {
+        ...defaults,
+        description: "account sending transferFrom not approved to transfer debt token",
+        sender: UNAPPROVED_TRANSFER_FROM_SENDER,
+        errorType: "ACCOUNT_UNAUTHORIZED_TO_TRANSFER",
+        errorMessage: DebtTokenAPIErrors.ACCOUNT_UNAUTHORIZED_TO_TRANSFER(
+            UNAPPROVED_TRANSFER_FROM_SENDER,
+        ),
+    },
+    {
+        ...defaults,
+        description: "data field is non-hexadecimal",
+        data: "non-hexadecimal string",
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'instance does not match pattern "^0x[0-9a-fA-F]*$"',
+    },
+    {
+        ...defaults,
+        description: "from field is malformed",
+        from: "0x123",
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'instance does not match pattern "^0x[0-9a-fA-F]{40}$"',
+    },
+    {
+        ...defaults,
+        description: "to field is malformed",
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => malformed,
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'instance does not match pattern "^0x[0-9a-fA-F]{40}$"',
+    },
+    {
+        ...defaults,
+        description: "recipient account is contract that does not implement ERC721Receiver",
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            nonCreditorsTokenID: BigNumber,
+            nonExistentTokenId: BigNumber,
+        ) => ordersIssuanceHash,
+        errorType: "CONTRACT_RECIPIENT_DOES_NOT_RECOGNIZE_721",
+        errorMessage: "does not implement the ERC721Receiver interface",
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+        ) => invalidContractRecipient,
+    },
+];

--- a/__test__/integration/debt_token_api/scenarios/unsuccessful_transfer_from.ts
+++ b/__test__/integration/debt_token_api/scenarios/unsuccessful_transfer_from.ts
@@ -52,7 +52,7 @@ export const UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS: DebtTokenScenario.TransferFro
             nonExistentTokenId: BigNumber,
         ) => nonExistentTokenId,
         errorType: "TOKEN_DOES_NOT_EXIST",
-        errorMessage: DebtTokenAPIErrors.TOKEN_DOES_NOT_EXIST(new BigNumber(13)),
+        errorMessage: DebtTokenAPIErrors.TOKEN_WITH_ID_DOES_NOT_EXIST(),
     },
     {
         ...defaults,
@@ -63,7 +63,7 @@ export const UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS: DebtTokenScenario.TransferFro
             nonExistentTokenId: BigNumber,
         ) => nonCreditorsTokenID,
         errorType: "TOKEN_DOES_NOT_BELONG_TO_ACCOUNT",
-        errorMessage: DebtTokenAPIErrors.TOKEN_DOES_NOT_BELONG_TO_ACCOUNT(Orders.CREDITOR),
+        errorMessage: DebtTokenAPIErrors.ONLY_OWNER(Orders.CREDITOR),
     },
     {
         ...defaults,

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "cross-env": "^5.0.1",
         "cz-conventional-changelog": "^2.0.0",
         "ethereumjs-abi": "^0.6.5",
-        "ganache-cli": "6.1.0",
+        "ganache-cli": "beta",
         "husky": "^0.14.0",
         "jest": "^22.0.2",
         "lint-staged": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "webpack": "^3.11.0"
     },
     "dependencies": {
-        "@dharmaprotocol/contracts": "0.0.30",
+        "@dharmaprotocol/contracts": "0.0.31",
         "@types/lodash": "^4.14.104",
         "abi-decoder": "https://github.com/dharmaprotocol/abi-decoder",
         "bignumber.js": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "cross-env": "^5.0.1",
         "cz-conventional-changelog": "^2.0.0",
         "ethereumjs-abi": "^0.6.5",
-        "ganache-cli": "beta",
+        "ganache-cli": "6.1.0",
         "husky": "^0.14.0",
         "jest": "^22.0.2",
         "lint-staged": "^6.0.0",
@@ -124,7 +124,7 @@
         "webpack": "^3.11.0"
     },
     "dependencies": {
-        "@dharmaprotocol/contracts": "0.0.27",
+        "@dharmaprotocol/contracts": "0.0.30",
         "@types/lodash": "^4.14.104",
         "abi-decoder": "https://github.com/dharmaprotocol/abi-decoder",
         "bignumber.js": "^5.0.0",

--- a/src/apis/debt_token_api.ts
+++ b/src/apis/debt_token_api.ts
@@ -1,9 +1,19 @@
+// External
 import * as Web3 from "web3";
-import { TxData, TransactionOptions } from "../types";
 import { BigNumber } from "bignumber.js";
-import { Web3Utils } from "../../utils/web3_utils";
-import { ContractsAPI } from "./";
+import * as singleLineString from "single-line-string";
+
+// Types
+import { TxData, TransactionOptions } from "../types";
+
+// Utils
 import { Assertions } from "../invariants";
+
+// APIs
+import { ContractsAPI } from "./";
+
+// Wrappers
+import { DebtTokenContract } from "../wrappers";
 
 export interface ERC721 {
     balanceOf(owner: string): Promise<BigNumber>;
@@ -27,6 +37,23 @@ export interface ERC721 {
 }
 
 const ERC721_TRANSFER_GAS_MAXIMUM = 200000;
+
+export const DebtTokenAPIErrors = {
+    TOKEN_DOES_NOT_EXIST: (tokenID: BigNumber) => singleLineString`
+        Token with ID ${tokenID.toNumber()} does not exist.
+    `,
+    TOKEN_DOES_NOT_BELONG_TO_ACCOUNT: (account: string) => singleLineString`
+        Specified token does not belong to account ${account}
+    `,
+    ACCOUNT_UNAUTHORIZED_TO_TRANSFER: (account: string) => singleLineString`
+        Transaction sender ${account} neither owns the specified token nor is approved to transfer it.
+    `,
+    RECIPIENT_WONT_RECOGNIZE_TOKEN: (recipient: string) => singleLineString`
+        Recipient ${recipient} is a contract that does not implement the
+        ERC721Receiver interface, and therefore cannot have ERC721 tokens
+        transferred to it.
+    `,
+};
 
 export class DebtTokenAPI implements ERC721 {
     private web3: Web3;
@@ -109,12 +136,18 @@ export class DebtTokenAPI implements ERC721 {
         data?: string,
         options?: TxData,
     ): Promise<string> {
-        const debtTokenContract = await this.contracts.loadDebtTokenAsync();
+        this.validateTransferFromArguments(from, to, tokenID, data);
+
         const txOptions = await TransactionOptions.generateTxOptions(
             this.web3,
             ERC721_TRANSFER_GAS_MAXIMUM,
             options,
         );
+
+        const debtTokenContract = await this.contracts.loadDebtTokenAsync();
+
+        await this.assertTransferFromValid(debtTokenContract, from, to, tokenID, data, txOptions);
+
         return debtTokenContract.safeTransferFrom.sendTransactionAsync(
             from,
             to,
@@ -122,5 +155,62 @@ export class DebtTokenAPI implements ERC721 {
             data,
             txOptions,
         );
+    }
+
+    private async assertTransferFromValid(
+        debtTokenContract: DebtTokenContract,
+        from: string,
+        to: string,
+        tokenID: BigNumber,
+        data: string,
+        txOptions: TxData,
+    ): Promise<void> {
+        // Assert token exists
+        await this.assert.debtToken.exists(
+            debtTokenContract,
+            tokenID,
+            DebtTokenAPIErrors.TOKEN_DOES_NOT_EXIST(tokenID),
+        );
+
+        // Assert token belongs to `from`
+        await this.assert.debtToken.belongsToAccount(
+            debtTokenContract,
+            tokenID,
+            from,
+            DebtTokenAPIErrors.TOKEN_DOES_NOT_BELONG_TO_ACCOUNT(from),
+        );
+
+        // Assert that message sender can transfer said token
+        await this.assert.debtToken.canBeTransferredByAccount(
+            debtTokenContract,
+            tokenID,
+            txOptions.from,
+            DebtTokenAPIErrors.ACCOUNT_UNAUTHORIZED_TO_TRANSFER(txOptions.from),
+        );
+
+        // Assert that `to` can be the recipient of an ERC721 token
+        await this.assert.debtToken.canBeReceivedByAccountWithData(
+            this.web3,
+            tokenID,
+            to,
+            from,
+            data,
+            DebtTokenAPIErrors.RECIPIENT_WONT_RECOGNIZE_TOKEN(to),
+        );
+    }
+
+    private validateTransferFromArguments(
+        from: string,
+        to: string,
+        tokenID: BigNumber,
+        data?: string,
+    ): void {
+        this.assert.schema.address("from", from);
+        this.assert.schema.address("to", to);
+        this.assert.schema.wholeNumber("tokenID", tokenID);
+
+        if (data) {
+            this.assert.schema.bytes("data", data);
+        }
     }
 }

--- a/src/apis/debt_token_api.ts
+++ b/src/apis/debt_token_api.ts
@@ -196,7 +196,7 @@ export class DebtTokenAPI implements ERC721 {
         );
 
         // Assert token belongs to `from`
-        await this.assert.debtToken.belongsToAccount(
+        await this.assert.debtToken.onlyOwner(
             debtTokenContract,
             tokenID,
             from,

--- a/src/invariants/debt_token.ts
+++ b/src/invariants/debt_token.ts
@@ -1,5 +1,7 @@
-import { DebtTokenContract } from "../wrappers";
+import { DebtTokenContract, ERC721ReceiverContract } from "../wrappers";
 import { BigNumber } from "bignumber.js";
+import * as Web3 from "web3";
+import { Web3Utils } from "utils/web3_utils";
 
 export class DebtTokenAssertions {
     public async exists(
@@ -54,6 +56,38 @@ export class DebtTokenAssertions {
             }
         } catch (e) {
             throw new Error(errorMessage);
+        }
+    }
+
+    public async canBeReceivedByAccountWithData(
+        web3: Web3,
+        tokenID: BigNumber,
+        recipient: string,
+        sender: string,
+        data: string = "",
+        errorMessage: string,
+    ): Promise<void> {
+        const utils = new Web3Utils(web3);
+        const isRecipientContract = await utils.doesContractExistAtAddressAsync(recipient);
+
+        // If a transfer recipient is a contract, it must implement the ERC721 Wallet interface
+        if (isRecipientContract) {
+            const EMPTY_TX_DEFAULTS = {};
+
+            const erc721Receiver = await ERC721ReceiverContract.at(
+                recipient,
+                web3,
+                EMPTY_TX_DEFAULTS,
+            );
+
+            // We check whether the recipient will accurately register a 721 interface
+            // by sending a message call to onERC721Received method (which is not mined)
+            // and seeing whether the call reverts.
+            try {
+                await erc721Receiver.onERC721Received.callAsync(sender, tokenID, data);
+            } catch (e) {
+                throw new Error(errorMessage);
+            }
         }
     }
 }

--- a/src/invariants/schema.ts
+++ b/src/invariants/schema.ts
@@ -31,6 +31,10 @@ export class SchemaAssertions {
         this.assertConformsToSchema(variableName, value, Schemas.bytes32Schema);
     }
 
+    public bytes(variableName: string, value: any) {
+        this.assertConformsToSchema(variableName, value, Schemas.bytesSchema);
+    }
+
     public number(variableName: string, value: any) {
         this.assertConformsToSchema(variableName, value, Schemas.numberSchema);
     }

--- a/src/schemas/basic_type_schemas.ts
+++ b/src/schemas/basic_type_schemas.ts
@@ -10,6 +10,12 @@ export const bytes32Schema = {
     pattern: "^0x[0-9a-fA-F]{64}$",
 };
 
+export const bytesSchema = {
+    id: "/Bytes",
+    type: "string",
+    pattern: "^0x[0-9a-fA-F]*$",
+};
+
 export const numberSchema = {
     id: "/Number",
     type: "object",

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -2,6 +2,7 @@ import {
     addressSchema,
     numberSchema,
     bytes32Schema,
+    bytesSchema,
     wholeNumberSchema,
 } from "./basic_type_schemas";
 import {
@@ -17,6 +18,7 @@ export const Schemas = {
     addressSchema,
     numberSchema,
     bytes32Schema,
+    bytesSchema,
     debtOrderSchema,
     debtOrderWithTermsSpecifiedSchema,
     debtOrderWithTermsAndDebtorSpecifiedSchema,

--- a/src/types/transaction_options.ts
+++ b/src/types/transaction_options.ts
@@ -4,6 +4,7 @@ import { Web3Utils } from "../../utils/web3_utils";
 
 export interface TxData {
     from?: string;
+    to?: string;
     gas?: number;
     gasPrice?: BigNumber;
     nonce?: number;

--- a/src/wrappers/contract_wrappers/base_contract_wrapper.ts
+++ b/src/wrappers/contract_wrappers/base_contract_wrapper.ts
@@ -3,17 +3,7 @@ import * as isUndefined from "lodash.isundefined";
 import { BigNumber } from "../../../utils/bignumber";
 import * as Web3 from "web3";
 import * as singleLineString from "single-line-string";
-
-export interface TxData {
-    from?: string;
-    gas?: number;
-    gasPrice?: BigNumber;
-    nonce?: number;
-}
-
-export interface TxDataPayable extends TxData {
-    value?: BigNumber;
-}
+import { TxData, TxDataPayable } from "src/types/";
 
 export const CONTRACT_WRAPPER_ERRORS = {
     CONTRACT_NOT_FOUND_ON_NETWORK: (contractName: string, networkId: number) =>

--- a/src/wrappers/contract_wrappers/erc721_receiver_wrapper.ts
+++ b/src/wrappers/contract_wrappers/erc721_receiver_wrapper.ts
@@ -1,0 +1,86 @@
+/**
+ * This file is auto-generated using abi-gen. Don't edit directly.
+ * Templates can be found at https://github.com/0xProject/0x.js/tree/development/packages/abi-gen-templates.
+ */
+// tslint:disable-next-line:no-unused-variable
+import { TxData, TxDataPayable } from "../../types";
+import * as promisify from "tiny-promisify";
+import { classUtils } from "../../../utils/class_utils";
+import { Web3Utils } from "../../../utils/web3_utils";
+import { BigNumber } from "../../../utils/bignumber";
+import { ERC721Receiver as ContractArtifacts } from "@dharmaprotocol/contracts";
+import * as Web3 from "web3";
+
+import { BaseContract, CONTRACT_WRAPPER_ERRORS } from "./base_contract_wrapper";
+
+export class ERC721ReceiverContract extends BaseContract {
+    public onERC721Received = {
+        async callAsync(
+            _from: string,
+            _tokenId: BigNumber,
+            _data: string,
+            defaultBlock?: Web3.BlockParam,
+        ): Promise<string> {
+            const self = this as ERC721ReceiverContract;
+            const result = await promisify<string>(
+                self.web3ContractInstance.onERC721Received.call,
+                self.web3ContractInstance,
+            )(_from, _tokenId, _data);
+            return result;
+        },
+        async estimateGasAsync(
+            _from: string,
+            _tokenId: BigNumber,
+            _data: string,
+            txData: TxData = {},
+        ): Promise<number> {
+            const self = this as ERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
+            const gas = await promisify<number>(
+                self.web3ContractInstance.onERC721Received.estimateGas,
+                self.web3ContractInstance,
+            )(_from, _tokenId, _data, txDataWithDefaults);
+            return gas;
+        },
+        getABIEncodedTransactionData(
+            _from: string,
+            _tokenId: BigNumber,
+            _data: string,
+            txData: TxData = {},
+        ): string {
+            const self = this as ERC721ReceiverContract;
+            const abiEncodedTransactionData = self.web3ContractInstance.onERC721Received.getData();
+            return abiEncodedTransactionData;
+        },
+    };
+
+    constructor(web3ContractInstance: Web3.ContractInstance, defaults: Partial<TxData>) {
+        super(web3ContractInstance, defaults);
+        classUtils.bindAll(this, ["web3ContractInstance", "defaults"]);
+    }
+
+    public static async at(
+        address: string,
+        web3: Web3,
+        defaults: Partial<TxData>,
+    ): Promise<ERC721ReceiverContract> {
+        const web3Utils = new Web3Utils(web3);
+
+        const { abi }: { abi: any } = ContractArtifacts;
+        const contractExists = await web3Utils.doesContractExistAtAddressAsync(address);
+        const currentNetwork = await web3Utils.getNetworkIdAsync();
+
+        if (contractExists) {
+            const web3ContractInstance = web3.eth.contract(abi).at(address);
+
+            return new ERC721ReceiverContract(web3ContractInstance, defaults);
+        } else {
+            throw new Error(
+                CONTRACT_WRAPPER_ERRORS.CONTRACT_NOT_FOUND_ON_NETWORK(
+                    "ERC721Receiver",
+                    currentNetwork,
+                ),
+            );
+        }
+    }
+} // tslint:disable:max-file-line-count

--- a/src/wrappers/contract_wrappers/mock_erc721_receiver_wrapper.ts
+++ b/src/wrappers/contract_wrappers/mock_erc721_receiver_wrapper.ts
@@ -1,0 +1,287 @@
+/**
+ * This file is auto-generated using abi-gen. Don't edit directly.
+ * Templates can be found at https://github.com/0xProject/0x.js/tree/development/packages/abi-gen-templates.
+ */
+// tslint:disable-next-line:no-unused-variable
+import { TxData, TxDataPayable } from "../../types";
+import * as promisify from "tiny-promisify";
+import { classUtils } from "../../../utils/class_utils";
+import { Web3Utils } from "../../../utils/web3_utils";
+import { BigNumber } from "../../../utils/bignumber";
+import { MockERC721Receiver as ContractArtifacts } from "@dharmaprotocol/contracts";
+import * as Web3 from "web3";
+
+import { BaseContract, CONTRACT_WRAPPER_ERRORS } from "./base_contract_wrapper";
+
+export class MockERC721ReceiverContract extends BaseContract {
+    public getMockReturnValue = {
+        async callAsync(
+            functionName: string,
+            argsSignature: string,
+            defaultBlock?: Web3.BlockParam,
+        ): Promise<string> {
+            const self = this as MockERC721ReceiverContract;
+            const result = await promisify<string>(
+                self.web3ContractInstance.getMockReturnValue.call,
+                self.web3ContractInstance,
+            )(functionName, argsSignature);
+            return result;
+        },
+    };
+    public setReturnValueForERC721ReceivedHook = {
+        async sendTransactionAsync(_returnValue: string, txData: TxData = {}): Promise<string> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
+                txData,
+                self.setReturnValueForERC721ReceivedHook.estimateGasAsync.bind(self, _returnValue),
+            );
+            const txHash = await promisify<string>(
+                self.web3ContractInstance.setReturnValueForERC721ReceivedHook,
+                self.web3ContractInstance,
+            )(_returnValue, txDataWithDefaults);
+            return txHash;
+        },
+        async estimateGasAsync(_returnValue: string, txData: TxData = {}): Promise<number> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
+            const gas = await promisify<number>(
+                self.web3ContractInstance.setReturnValueForERC721ReceivedHook.estimateGas,
+                self.web3ContractInstance,
+            )(_returnValue, txDataWithDefaults);
+            return gas;
+        },
+        getABIEncodedTransactionData(_returnValue: string, txData: TxData = {}): string {
+            const self = this as MockERC721ReceiverContract;
+            const abiEncodedTransactionData = self.web3ContractInstance.setReturnValueForERC721ReceivedHook.getData();
+            return abiEncodedTransactionData;
+        },
+    };
+    public setShouldRevert = {
+        async sendTransactionAsync(_shouldRevert: boolean, txData: TxData = {}): Promise<string> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
+                txData,
+                self.setShouldRevert.estimateGasAsync.bind(self, _shouldRevert),
+            );
+            const txHash = await promisify<string>(
+                self.web3ContractInstance.setShouldRevert,
+                self.web3ContractInstance,
+            )(_shouldRevert, txDataWithDefaults);
+            return txHash;
+        },
+        async estimateGasAsync(_shouldRevert: boolean, txData: TxData = {}): Promise<number> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
+            const gas = await promisify<number>(
+                self.web3ContractInstance.setShouldRevert.estimateGas,
+                self.web3ContractInstance,
+            )(_shouldRevert, txDataWithDefaults);
+            return gas;
+        },
+        getABIEncodedTransactionData(_shouldRevert: boolean, txData: TxData = {}): string {
+            const self = this as MockERC721ReceiverContract;
+            const abiEncodedTransactionData = self.web3ContractInstance.setShouldRevert.getData();
+            return abiEncodedTransactionData;
+        },
+    };
+    public mockReturnValue = {
+        async sendTransactionAsync(
+            functionName: string,
+            argsSignature: string,
+            returnValue: string,
+            txData: TxData = {},
+        ): Promise<string> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
+                txData,
+                self.mockReturnValue.estimateGasAsync.bind(
+                    self,
+                    functionName,
+                    argsSignature,
+                    returnValue,
+                ),
+            );
+            const txHash = await promisify<string>(
+                self.web3ContractInstance.mockReturnValue,
+                self.web3ContractInstance,
+            )(functionName, argsSignature, returnValue, txDataWithDefaults);
+            return txHash;
+        },
+        async estimateGasAsync(
+            functionName: string,
+            argsSignature: string,
+            returnValue: string,
+            txData: TxData = {},
+        ): Promise<number> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
+            const gas = await promisify<number>(
+                self.web3ContractInstance.mockReturnValue.estimateGas,
+                self.web3ContractInstance,
+            )(functionName, argsSignature, returnValue, txDataWithDefaults);
+            return gas;
+        },
+        getABIEncodedTransactionData(
+            functionName: string,
+            argsSignature: string,
+            returnValue: string,
+            txData: TxData = {},
+        ): string {
+            const self = this as MockERC721ReceiverContract;
+            const abiEncodedTransactionData = self.web3ContractInstance.mockReturnValue.getData();
+            return abiEncodedTransactionData;
+        },
+    };
+    public wasOnERC721ReceivedCalledWith = {
+        async callAsync(
+            _address: string,
+            _tokenId: BigNumber,
+            _data: string,
+            defaultBlock?: Web3.BlockParam,
+        ): Promise<boolean> {
+            const self = this as MockERC721ReceiverContract;
+            const result = await promisify<boolean>(
+                self.web3ContractInstance.wasOnERC721ReceivedCalledWith.call,
+                self.web3ContractInstance,
+            )(_address, _tokenId, _data);
+            return result;
+        },
+    };
+    public reset = {
+        async sendTransactionAsync(txData: TxData = {}): Promise<string> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
+                txData,
+                self.reset.estimateGasAsync.bind(self),
+            );
+            const txHash = await promisify<string>(
+                self.web3ContractInstance.reset,
+                self.web3ContractInstance,
+            )(txDataWithDefaults);
+            return txHash;
+        },
+        async estimateGasAsync(txData: TxData = {}): Promise<number> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
+            const gas = await promisify<number>(
+                self.web3ContractInstance.reset.estimateGas,
+                self.web3ContractInstance,
+            )(txDataWithDefaults);
+            return gas;
+        },
+        getABIEncodedTransactionData(txData: TxData = {}): string {
+            const self = this as MockERC721ReceiverContract;
+            const abiEncodedTransactionData = self.web3ContractInstance.reset.getData();
+            return abiEncodedTransactionData;
+        },
+    };
+    public onERC721Received = {
+        async sendTransactionAsync(
+            _address: string,
+            _tokenId: BigNumber,
+            _data: string,
+            txData: TxData = {},
+        ): Promise<string> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(
+                txData,
+                self.onERC721Received.estimateGasAsync.bind(self, _address, _tokenId, _data),
+            );
+            const txHash = await promisify<string>(
+                self.web3ContractInstance.onERC721Received,
+                self.web3ContractInstance,
+            )(_address, _tokenId, _data, txDataWithDefaults);
+            return txHash;
+        },
+        async estimateGasAsync(
+            _address: string,
+            _tokenId: BigNumber,
+            _data: string,
+            txData: TxData = {},
+        ): Promise<number> {
+            const self = this as MockERC721ReceiverContract;
+            const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
+            const gas = await promisify<number>(
+                self.web3ContractInstance.onERC721Received.estimateGas,
+                self.web3ContractInstance,
+            )(_address, _tokenId, _data, txDataWithDefaults);
+            return gas;
+        },
+        getABIEncodedTransactionData(
+            _address: string,
+            _tokenId: BigNumber,
+            _data: string,
+            txData: TxData = {},
+        ): string {
+            const self = this as MockERC721ReceiverContract;
+            const abiEncodedTransactionData = self.web3ContractInstance.onERC721Received.getData();
+            return abiEncodedTransactionData;
+        },
+    };
+
+    constructor(web3ContractInstance: Web3.ContractInstance, defaults: Partial<TxData>) {
+        super(web3ContractInstance, defaults);
+        classUtils.bindAll(this, ["web3ContractInstance", "defaults"]);
+    }
+
+    public static async deployed(
+        web3: Web3,
+        defaults: Partial<TxData>,
+    ): Promise<MockERC721ReceiverContract> {
+        const web3Utils = new Web3Utils(web3);
+
+        const currentNetwork = await web3Utils.getNetworkIdAsync();
+        const { abi, networks }: { abi: any; networks: any } = ContractArtifacts;
+
+        if (networks[currentNetwork]) {
+            const { address: contractAddress } = networks[currentNetwork];
+
+            const contractExists = await web3Utils.doesContractExistAtAddressAsync(contractAddress);
+
+            if (contractExists) {
+                const web3ContractInstance = web3.eth.contract(abi).at(contractAddress);
+                return new MockERC721ReceiverContract(web3ContractInstance, defaults);
+            } else {
+                throw new Error(
+                    CONTRACT_WRAPPER_ERRORS.CONTRACT_NOT_FOUND_ON_NETWORK(
+                        "DebtKernel",
+                        currentNetwork,
+                    ),
+                );
+            }
+        } else {
+            throw new Error(
+                CONTRACT_WRAPPER_ERRORS.CONTRACT_NOT_FOUND_ON_NETWORK(
+                    "MockERC721Receiver",
+                    currentNetwork,
+                ),
+            );
+        }
+    }
+
+    public static async at(
+        address: string,
+        web3: Web3,
+        defaults: Partial<TxData>,
+    ): Promise<MockERC721ReceiverContract> {
+        const web3Utils = new Web3Utils(web3);
+
+        const { abi }: { abi: any } = ContractArtifacts;
+
+        const contractExists = await web3Utils.doesContractExistAtAddressAsync(address);
+        const currentNetwork = await web3Utils.getNetworkIdAsync();
+
+        if (contractExists) {
+            const web3ContractInstance = web3.eth.contract(abi).at(address);
+
+            return new MockERC721ReceiverContract(web3ContractInstance, defaults);
+        } else {
+            throw new Error(
+                CONTRACT_WRAPPER_ERRORS.CONTRACT_NOT_FOUND_ON_NETWORK(
+                    "MockERC721Receiver",
+                    currentNetwork,
+                ),
+            );
+        }
+    }
+} // tslint:disable:max-file-line-count

--- a/src/wrappers/index.ts
+++ b/src/wrappers/index.ts
@@ -7,6 +7,7 @@ import { DummyTokenContract } from "./contract_wrappers/dummy_token_wrapper";
 import { TokenRegistryContract } from "./contract_wrappers/token_registry_wrapper";
 import { TokenTransferProxyContract } from "./contract_wrappers/token_transfer_proxy_wrapper";
 import { ERC20Contract } from "./contract_wrappers/erc20_wrapper";
+import { ERC721ReceiverContract } from "./contract_wrappers/erc721_receiver_wrapper";
 import { MockERC721ReceiverContract } from "./contract_wrappers/mock_erc721_receiver_wrapper";
 import { TermsContract } from "./contract_wrappers/terms_contract_wrapper";
 import { RepaymentRouterContract } from "./contract_wrappers/repayment_router_wrapper";
@@ -19,6 +20,7 @@ export type ContractWrapper =
     | DebtTokenContract
     | TokenTransferProxyContract
     | ERC20Contract
+    | ERC721ReceiverContract
     | MockERC721ReceiverContract
     | RepaymentRouterContract
     | SimpleInterestTermsContractContract
@@ -36,6 +38,7 @@ export {
     TokenRegistryContract,
     TokenTransferProxyContract,
     ERC20Contract,
+    ERC721ReceiverContract,
     MockERC721ReceiverContract,
     TermsContract,
     SimpleInterestTermsContractContract,

--- a/src/wrappers/index.ts
+++ b/src/wrappers/index.ts
@@ -7,6 +7,7 @@ import { DummyTokenContract } from "./contract_wrappers/dummy_token_wrapper";
 import { TokenRegistryContract } from "./contract_wrappers/token_registry_wrapper";
 import { TokenTransferProxyContract } from "./contract_wrappers/token_transfer_proxy_wrapper";
 import { ERC20Contract } from "./contract_wrappers/erc20_wrapper";
+import { MockERC721ReceiverContract } from "./contract_wrappers/mock_erc721_receiver_wrapper";
 import { TermsContract } from "./contract_wrappers/terms_contract_wrapper";
 import { RepaymentRouterContract } from "./contract_wrappers/repayment_router_wrapper";
 import { SimpleInterestTermsContractContract } from "./contract_wrappers/simple_interest_terms_contract_wrapper";
@@ -18,6 +19,7 @@ export type ContractWrapper =
     | DebtTokenContract
     | TokenTransferProxyContract
     | ERC20Contract
+    | MockERC721ReceiverContract
     | RepaymentRouterContract
     | SimpleInterestTermsContractContract
     | CollateralizedSimpleInterestTermsContractContract
@@ -34,6 +36,7 @@ export {
     TokenRegistryContract,
     TokenTransferProxyContract,
     ERC20Contract,
+    MockERC721ReceiverContract,
     TermsContract,
     SimpleInterestTermsContractContract,
     CollateralizedSimpleInterestTermsContractContract,

--- a/utils/transaction_utils.ts
+++ b/utils/transaction_utils.ts
@@ -1,0 +1,52 @@
+// External
+import * as Web3 from "web3";
+import * as ethjsABI from "ethjs-abi";
+import * as promisify from "tiny-promisify";
+
+// Types
+import { TxData } from "src/types";
+
+export namespace TransactionUtils {
+    function filterMethodABI(abi: any[]): Web3.MethodAbi[] {
+        return abi.filter((abiDef) => abiDef.type === "function");
+    }
+
+    function findMethod(
+        abi: Web3.AbiDefinition[],
+        name: string,
+        inputTypes: string,
+    ): Web3.MethodAbi {
+        const methodAbi = filterMethodABI(abi).find((abiDef) => {
+            const methodArgs = abiDef.inputs.map((input) => input.type).join(",");
+            return abiDef.name === name && methodArgs === inputTypes;
+        });
+
+        if (methodAbi) {
+            return methodAbi;
+        }
+
+        throw new Error(`Method: ${name} with input types: ${inputTypes} is not found`);
+    }
+
+    // sendTransaction is a util function to send a transaction to any overloaded
+    // method of a contract.
+    // Truffle contract instance cannot handle overloaded methods
+    // (truffle will only handle the first implementation of the method).
+    export async function sendRawTransaction(
+        web3: Web3,
+        web3ContractInstance: Web3.ContractInstance,
+        methodName: string,
+        inputTypes: string,
+        inputVals: any[],
+        txData: TxData = {},
+    ): Promise<string> {
+        const abiMethod = findMethod(web3ContractInstance.abi, methodName, inputTypes);
+        const encodedData = ethjsABI.encodeMethod(abiMethod, inputVals);
+
+        return promisify<string>(web3.eth.sendTransaction)({
+            data: encodedData,
+            ...txData,
+            to: web3ContractInstance.address,
+        });
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,9 +132,9 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dharmaprotocol/contracts@0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.30.tgz#46915cf9c0267cdeb71c7c66b756f9da874cdfd3"
+"@dharmaprotocol/contracts@0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.31.tgz#67996e3b50b28f685e3b425afbb5f814788ef6ed"
   dependencies:
     zeppelin-solidity "^1.8.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,9 +132,9 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dharmaprotocol/contracts@0.0.27":
-  version "0.0.27"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.27.tgz#5015879e5e96d2eb2748ef37661f581d2978da42"
+"@dharmaprotocol/contracts@0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.30.tgz#46915cf9c0267cdeb71c7c66b756f9da874cdfd3"
   dependencies:
     zeppelin-solidity "^1.8.0"
 
@@ -452,6 +452,16 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
+
 ansicolors@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
@@ -522,6 +532,10 @@ arr-flatten@^1.0.1, arr-flatten@^1.1.0:
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+
+array-differ@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -615,6 +629,14 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
+ast-types@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.1.tgz#f52fca9715579a14f841d67d7f8d25432ab6a3dd"
+
+ast-types@0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.3.tgz#c20757fe72ee71278ea0ff3d87e5c2ca30d9edf8"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -627,11 +649,11 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
-async@^1.4.0:
+async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4:
+async@^2.1.2, async@^2.1.4, async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -748,6 +770,14 @@ babel-generator@^6.18.0, babel-generator@^6.26.0:
     source-map "^0.5.7"
     trim-right "^1.0.1"
 
+babel-helper-bindify-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz#14c19e5f142d7b47f19a52431e52b1ccbc40a330"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
@@ -778,6 +808,15 @@ babel-helper-explode-assignable-expression@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
   dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-explode-class@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz#7dc2a3910dee007056e1e31d640ced3d54eaa9eb"
+  dependencies:
+    babel-helper-bindify-decorators "^6.24.1"
     babel-runtime "^6.22.0"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
@@ -897,11 +936,39 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-async-generators@^6.5.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+
+babel-plugin-syntax-class-constructor-call@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz#9cb9d39fe43c8600bec8146456ddcbd4e1a76416"
+
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
+babel-plugin-syntax-decorators@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-export-extensions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz#70a1484f0f9089a4e84ad44bac353c95b9b12721"
+
+babel-plugin-syntax-flow@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -909,13 +976,48 @@ babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
 
-babel-plugin-transform-async-to-generator@^6.22.0:
+babel-plugin-transform-async-generator-functions@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz#f058900145fd3e9907a6ddf28da59f215258a5db"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-generators "^6.5.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-async-to-generator@^6.22.0, babel-plugin-transform-async-to-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
   dependencies:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-constructor-call@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz#80dc285505ac067dcb8d6c65e2f6f11ab7765ef9"
+  dependencies:
+    babel-plugin-syntax-class-constructor-call "^6.18.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz#788013d8f8c6b5222bdf7b344390dfd77569e24d"
+  dependencies:
+    babel-helper-explode-class "^6.24.1"
+    babel-plugin-syntax-decorators "^6.13.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -1085,13 +1187,34 @@ babel-plugin-transform-es2015-unicode-regex@^6.22.0, babel-plugin-transform-es20
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
-babel-plugin-transform-exponentiation-operator@^6.22.0:
+babel-plugin-transform-exponentiation-operator@^6.22.0, babel-plugin-transform-exponentiation-operator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
   dependencies:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-export-extensions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz#53738b47e75e8218589eea946cbbd39109bbe653"
+  dependencies:
+    babel-plugin-syntax-export-extensions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-flow-strip-types@^6.8.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
+  dependencies:
+    babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.24.1:
   version "6.26.0"
@@ -1155,7 +1278,7 @@ babel-preset-env@^1.6.1:
     invariant "^2.2.2"
     semver "^5.3.0"
 
-babel-preset-es2015@^6.22.0:
+babel-preset-es2015@^6.22.0, babel-preset-es2015@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -1191,7 +1314,34 @@ babel-preset-jest@^22.0.1, babel-preset-jest@^22.2.0:
     babel-plugin-jest-hoist "^22.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-register@^6.26.0:
+babel-preset-stage-1@^6.5.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz#7692cd7dcd6849907e6ae4a0a85589cfb9e2bfb0"
+  dependencies:
+    babel-plugin-transform-class-constructor-call "^6.24.1"
+    babel-plugin-transform-export-extensions "^6.22.0"
+    babel-preset-stage-2 "^6.24.1"
+
+babel-preset-stage-2@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz#d9e2960fb3d71187f0e64eec62bc07767219bdc1"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-plugin-transform-class-properties "^6.24.1"
+    babel-plugin-transform-decorators "^6.24.1"
+    babel-preset-stage-3 "^6.24.1"
+
+babel-preset-stage-3@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz#836ada0a9e7a7fa37cb138fb9326f87934a48395"
+  dependencies:
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-generator-functions "^6.24.1"
+    babel-plugin-transform-async-to-generator "^6.24.1"
+    babel-plugin-transform-exponentiation-operator "^6.24.1"
+    babel-plugin-transform-object-rest-spread "^6.22.0"
+
+babel-register@^6.26.0, babel-register@^6.9.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
   dependencies:
@@ -1243,9 +1393,13 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.18.0:
+babylon@^6.17.3, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+
+babylon@^7.0.0-beta.30:
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1300,6 +1454,10 @@ bignumber.js@~4.1.0:
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
+
+binaryextensions@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
 
 bindings@^1.2.1:
   version "1.3.0"
@@ -1710,6 +1868,26 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
 chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1773,6 +1951,12 @@ cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   dependencies:
     restore-cursor "^1.0.1"
 
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
 cli-spinners@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
@@ -1818,15 +2002,43 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+clone-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
+
 clone-response@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
   dependencies:
     mimic-response "^1.0.0"
 
+clone-stats@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
+
+clone-stats@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
+
+clone@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+
 clone@~0.1.9:
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/clone/-/clone-0.1.19.tgz#613fb68639b26a494ac53253e15b1a6bd88ada85"
+
+cloneable-readable@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.1.2.tgz#d591dee4a8f8bc15da43ce97dceeba13d43e2a65"
+  dependencies:
+    inherits "^2.0.1"
+    process-nextick-args "^2.0.0"
+    readable-stream "^2.3.5"
 
 co@^4.6.0:
   version "4.6.0"
@@ -2066,6 +2278,10 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
+core-js@^2.4.1:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2169,6 +2385,16 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@0.2.x:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-0.2.2.tgz#ed91ff1f17ad13d3748288594f8a48a0d26f325c"
@@ -2268,6 +2494,10 @@ dargs@^4.0.1:
   dependencies:
     number-is-nan "^1.0.0"
 
+dargs@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dargs/-/dargs-5.1.0.tgz#ec7ea50c78564cd36c9d5ec18f66329fade27829"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -2288,6 +2518,10 @@ dateformat@^1.0.11:
   dependencies:
     get-stdin "^4.0.1"
     meow "^3.3.0"
+
+dateformat@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
@@ -2316,7 +2550,7 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
-decompress-response@^3.3.0:
+decompress-response@^3.2.0, decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
   dependencies:
@@ -2344,7 +2578,7 @@ deep-equal@~0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.2.2.tgz#84b745896f34c684e98f2ce0e42abaf43bba017d"
 
-deep-extend@~0.4.0:
+deep-extend@^0.4.0, deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
@@ -2425,6 +2659,10 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+detect-conflict@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/detect-conflict/-/detect-conflict-1.0.1.tgz#088657a66a961c05019db7c4230883b1c6b4176e"
+
 detect-file@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"
@@ -2448,6 +2686,10 @@ detect-newline@^2.1.0:
 diff@^3.1.0, diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
+diff@^3.3.1, diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -2529,9 +2771,17 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+editions@^1.3.3:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+ejs@^2.3.1:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.8.tgz#2ab6954619f225e6193b7ac5f7c39c48fefe4380"
 
 electron-to-chromium@^1.3.30:
   version "1.3.33"
@@ -2579,6 +2829,18 @@ enhanced-resolve@^3.3.0, enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
+enhanced-resolve@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz#e34a6eaa790f62fccd71d93959f56b2b432db10a"
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.4.0"
+    tapable "^1.0.0"
+
+envinfo@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-4.4.2.tgz#472c49f3a8b9bca73962641ce7cb692bf623cd1c"
+
 errno@^0.1.1, errno@~0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.6.tgz#c386ce8a6283f14fc09563b71560908c9bf53026"
@@ -2596,6 +2858,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+error@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/error/-/error-7.0.2.tgz#a5f75fff4d9926126ddac0ea5dc38e689153cb02"
+  dependencies:
+    string-template "~0.2.1"
+    xtend "~4.0.0"
 
 es-abstract@^1.5.1:
   version "1.10.0"
@@ -2709,7 +2978,7 @@ esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
@@ -2913,6 +3182,12 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 expect@^22.2.2:
   version "22.2.2"
   resolved "https://registry.yarnpkg.com/expect/-/expect-22.2.2.tgz#6cb6ae2eeb651a4187b9096de70333a018fab63f"
@@ -2984,6 +3259,14 @@ external-editor@^1.1.0:
     spawn-sync "^1.0.15"
     tmp "^0.0.29"
 
+external-editor@^2.0.4, external-editor@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -3039,6 +3322,12 @@ figures@^1.3.5, figures@^1.7.0:
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -3130,6 +3419,16 @@ findup-sync@0.4.2:
     is-glob "^2.0.1"
     micromatch "^2.3.7"
     resolve-dir "^0.1.0"
+
+first-chunk-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
+  dependencies:
+    readable-stream "^2.0.2"
+
+flow-parser@^0.*:
+  version "0.69.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.69.0.tgz#378b5128d6d0b554a8b2f16a4ca3e1ab9649f00e"
 
 for-each@^0.3.2:
   version "0.3.2"
@@ -3274,12 +3573,12 @@ fwd-stream@^1.0.4:
   dependencies:
     readable-stream "~1.0.26-4"
 
-ganache-cli@beta:
-  version "6.1.0-beta.0"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.0-beta.0.tgz#0d112fe36af84031b5f638d1d7300393996c3e25"
+ganache-cli@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.0.tgz#486c846497204b644166b5f0f74c9b41d02bdc25"
   dependencies:
-    source-map-support "^0.5.0"
-    webpack "^3.10.0"
+    source-map-support "^0.5.3"
+    webpack-cli "^2.0.9"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -3324,6 +3623,13 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gh-got@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gh-got/-/gh-got-6.0.0.tgz#d74353004c6ec466647520a10bd46f7299d268d0"
+  dependencies:
+    got "^7.0.0"
+    is-plain-obj "^1.1.0"
+
 git-log-parser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/git-log-parser/-/git-log-parser-1.2.0.tgz#2e6a4c1b13fc00028207ba795a7ac31667b9fd4a"
@@ -3358,6 +3664,12 @@ git-url-parse@^8.0.0:
   dependencies:
     git-up "^2.0.0"
 
+github-username@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/github-username/-/github-username-4.1.0.tgz#cbe280041883206da4212ae9e4b5f169c30bf417"
+  dependencies:
+    gh-got "^6.0.0"
+
 github@^13.0.1:
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/github/-/github-13.1.0.tgz#fc925950beebdff0cb0583197598b86f41bedaa4"
@@ -3369,6 +3681,13 @@ github@^13.0.1:
     lodash "^4.17.4"
     proxy-from-env "^1.0.0"
     url-template "^2.0.8"
+
+glob-all@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-all/-/glob-all-3.1.0.tgz#8913ddfb5ee1ac7812656241b03d5217c64b02ab"
+  dependencies:
+    glob "^7.0.5"
+    yargs "~1.2.6"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -3431,6 +3750,14 @@ global-modules@^0.2.3:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
 
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
@@ -3439,6 +3766,16 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 global@~4.3.0:
   version "4.3.2"
@@ -3450,6 +3787,16 @@ global@~4.3.0:
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 globby@^7.1.1:
   version "7.1.1"
@@ -3478,6 +3825,25 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
+got@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"
+  dependencies:
+    decompress-response "^3.2.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-plain-obj "^1.1.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    p-cancelable "^0.3.0"
+    p-timeout "^1.1.1"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    url-parse-lax "^1.0.0"
+    url-to-options "^1.0.1"
+
 got@^8.0.1:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/got/-/got-8.0.3.tgz#15d038e8101f89e93585d1639d9c49e8a55ae6bc"
@@ -3500,9 +3866,37 @@ got@^8.0.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
+got@^8.2.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.3.0.tgz#6ba26e75f8a6cc4c6b3eb1fe7ce4fec7abac8533"
+  dependencies:
+    "@sindresorhus/is" "^0.7.0"
+    cacheable-request "^2.1.1"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    into-stream "^3.1.0"
+    is-retry-allowed "^1.1.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    mimic-response "^1.0.0"
+    p-cancelable "^0.4.0"
+    p-timeout "^2.0.1"
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+    timed-out "^4.0.1"
+    url-parse-lax "^3.0.0"
+    url-to-options "^1.0.1"
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+grouped-queue@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/grouped-queue/-/grouped-queue-0.3.3.tgz#c167d2a5319c5a0e0964ef6a25b7c2df8996c85c"
+  dependencies:
+    lodash "^4.17.2"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -3545,6 +3939,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -3767,6 +4165,12 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
+iconv-lite@^0.4.17:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  dependencies:
+    safer-buffer "^2.1.0"
+
 idb-wrapper@^1.5.0:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/idb-wrapper/-/idb-wrapper-1.7.2.tgz#8251afd5e77fe95568b1c16152eb44b396767ea2"
@@ -3852,7 +4256,44 @@ inquirer@1.2.3:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
-interpret@^1.0.0:
+inquirer@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+interpret@^1.0.0, interpret@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
@@ -4140,6 +4581,12 @@ is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
+is-scoped@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-scoped/-/is-scoped-1.0.0.tgz#449ca98299e713038256289ecb2b540dc437cb30"
+  dependencies:
+    scoped-regex "^1.0.0"
+
 is-ssh@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.0.tgz#ebea1169a2614da392a63740366c3ce049d8dff6"
@@ -4180,7 +4627,7 @@ is-windows@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
-is-windows@^1.0.2:
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -4280,6 +4727,14 @@ istanbul-reports@^1.1.3:
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
   dependencies:
     handlebars "^4.0.3"
+
+istextorbinary@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-2.2.1.tgz#a5231a08ef6dd22b268d0895084cf8d58b5bec53"
+  dependencies:
+    binaryextensions "2"
+    editions "^1.3.3"
+    textextensions "2"
 
 isurl@^1.0.0-alpha5:
   version "1.0.0"
@@ -4574,6 +5029,46 @@ js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jscodeshift@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.4.1.tgz#da91a1c2eccfa03a3387a21d39948e251ced444a"
+  dependencies:
+    async "^1.5.0"
+    babel-plugin-transform-flow-strip-types "^6.8.0"
+    babel-preset-es2015 "^6.9.0"
+    babel-preset-stage-1 "^6.5.0"
+    babel-register "^6.9.0"
+    babylon "^6.17.3"
+    colors "^1.1.2"
+    flow-parser "^0.*"
+    lodash "^4.13.1"
+    micromatch "^2.3.7"
+    node-dir "0.1.8"
+    nomnom "^1.8.1"
+    recast "^0.12.5"
+    temp "^0.8.1"
+    write-file-atomic "^1.2.0"
+
+jscodeshift@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.5.0.tgz#bdb7b6cc20dd62c16aa728c3fa2d2fe66ca7c748"
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.8.0"
+    babel-preset-es2015 "^6.9.0"
+    babel-preset-stage-1 "^6.5.0"
+    babel-register "^6.9.0"
+    babylon "^7.0.0-beta.30"
+    colors "^1.1.2"
+    flow-parser "^0.*"
+    lodash "^4.13.1"
+    micromatch "^2.3.7"
+    neo-async "^2.5.0"
+    node-dir "0.1.8"
+    nomnom "^1.8.1"
+    recast "^0.14.1"
+    temp "^0.8.1"
+    write-file-atomic "^1.2.0"
 
 jsdom@^11.5.1:
   version "11.6.2"
@@ -5108,7 +5603,7 @@ lodash@4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -5124,7 +5619,7 @@ log-symbols@^1.0.2:
   dependencies:
     chalk "^1.0.0"
 
-log-symbols@^2.0.0:
+log-symbols@^2.0.0, log-symbols@^2.1.0, log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
   dependencies:
@@ -5187,6 +5682,12 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-dir@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.2.0.tgz#6d6a49eead4aae296c53bbf3a1a008bd6c89469b"
+  dependencies:
+    pify "^3.0.0"
+
 make-error@^1.1.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.3.tgz#a97ae14ffd98b05f543e83ddc395e1b2b6e4cc6a"
@@ -5243,6 +5744,29 @@ md5.js@^1.3.4:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+mem-fs-editor@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz#dd0a6eaf2bb8a6b37740067aa549eb530105af9f"
+  dependencies:
+    commondir "^1.0.1"
+    deep-extend "^0.4.0"
+    ejs "^2.3.1"
+    glob "^7.0.3"
+    globby "^6.1.0"
+    mkdirp "^0.5.0"
+    multimatch "^2.0.0"
+    rimraf "^2.2.8"
+    through2 "^2.0.0"
+    vinyl "^2.0.1"
+
+mem-fs@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/mem-fs/-/mem-fs-1.1.3.tgz#b8ae8d2e3fcb6f5d3f9165c12d4551a065d989cc"
+  dependencies:
+    through2 "^2.0.0"
+    vinyl "^1.1.0"
+    vinyl-file "^2.0.0"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -5444,6 +5968,10 @@ minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -5455,7 +5983,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5473,11 +6001,20 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+multimatch@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
+  dependencies:
+    array-differ "^1.0.0"
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    minimatch "^3.0.0"
+
 mute-stream@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
 
-mute-stream@~0.0.4:
+mute-stream@0.0.7, mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
@@ -5546,6 +6083,14 @@ nerf-dart@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/nerf-dart/-/nerf-dart-1.0.0.tgz#e6dab7febf5ad816ea81cf5c629c5a0ebde72c1a"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
+node-dir@0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.8.tgz#55fb8deb699070707fb67f91a460f0448294c77d"
+
 node-emoji@^1.4.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
@@ -5612,6 +6157,13 @@ node-pre-gyp@^0.6.39:
 node-uuid@~1.4.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
+
+nomnom@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -5806,6 +6358,12 @@ onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -5859,7 +6417,7 @@ os-shim@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -5882,6 +6440,16 @@ p-cancelable@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
 
+p-cancelable@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
+
+p-each-series@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
+  dependencies:
+    p-reduce "^1.0.0"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -5889,6 +6457,10 @@ p-finally@^1.0.0:
 p-is-promise@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
+
+p-lazy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-lazy/-/p-lazy-1.0.0.tgz#ec53c802f2ee3ac28f166cc82d0b2b02de27a835"
 
 p-limit@^1.1.0:
   version "1.2.0"
@@ -5915,6 +6487,12 @@ p-retry@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-1.0.0.tgz#3927332a4b7d70269b535515117fc547da1a6968"
   dependencies:
     retry "^0.10.0"
+
+p-timeout@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.2.1.tgz#5eb3b353b7fce99f101a1038880bb054ebbea386"
+  dependencies:
+    p-finally "^1.0.0"
 
 p-timeout@^2.0.1:
   version "2.0.1"
@@ -6047,7 +6625,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -6097,7 +6675,7 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -6163,6 +6741,14 @@ prettier@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
+prettier@^1.5.3:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
+
+pretty-bytes@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
+
 pretty-format@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
@@ -6177,7 +6763,7 @@ pretty-format@^22.1.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-private@^0.1.6, private@^0.1.7:
+private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -6185,7 +6771,7 @@ process-es6@^0.11.2, process-es6@^0.11.3:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/process-es6/-/process-es6-0.11.6.tgz#c6bb389f9a951f82bd4eb169600105bd2ff9c778"
 
-process-nextick-args@~2.0.0:
+process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
@@ -6356,6 +6942,13 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+read-chunk@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-2.1.0.tgz#6a04c0928005ed9d42e1a6ac5600e19cbc7ff655"
+  dependencies:
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -6440,6 +7033,18 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
+readable-stream@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 readable-stream@~1.0.26, readable-stream@~1.0.26-4:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -6463,6 +7068,25 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
+
+recast@^0.12.5:
+  version "0.12.9"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.12.9.tgz#e8e52bdb9691af462ccbd7c15d5a5113647a15f1"
+  dependencies:
+    ast-types "0.10.1"
+    core-js "^2.4.1"
+    esprima "~4.0.0"
+    private "~0.1.5"
+    source-map "~0.6.1"
+
+recast@^0.14.1:
+  version "0.14.7"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.14.7.tgz#4f1497c2b5826d42a66e8e3c9d80c512983ff61d"
+  dependencies:
+    ast-types "0.11.3"
+    esprima "~4.0.0"
+    private "~0.1.5"
+    source-map "~0.6.1"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -6577,6 +7201,14 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
+
+replace-ext@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 replace-in-file@^3.0.0-beta.2:
   version "3.1.1"
@@ -6707,6 +7339,13 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
+resolve-dir@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@4.0.0, resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -6752,6 +7391,13 @@ restore-cursor@^1.0.1:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 resumer@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
@@ -6780,11 +7426,15 @@ right-pad@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
 
-rimraf@2, rimraf@2.x.x, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
+
+rimraf@~2.2.6:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
@@ -6875,11 +7525,21 @@ rollup@^0.53.0:
   version "0.53.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.53.4.tgz#f92ce56ee1d097ad5b6f13951bc80db5fef18113"
 
-run-async@^2.2.0:
+run-async@^2.0.0, run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
+
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 rx@^4.1.0:
   version "4.1.0"
@@ -6888,6 +7548,12 @@ rx@^4.1.0:
 rxjs@^5.4.2:
   version "5.5.6"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
+
+rxjs@^5.5.2:
+  version "5.5.8"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.8.tgz#b2b0809a57614ad6254c03d7446dea0d83ca3791"
   dependencies:
     symbol-observable "1.0.1"
 
@@ -6900,6 +7566,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
+
+safer-buffer@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^2.0.0:
   version "2.4.1"
@@ -6918,6 +7588,10 @@ sane@^2.0.0:
 sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+scoped-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
 
 secp256k1@^3.0.1, secp256k1@^3.5.0:
   version "3.5.0"
@@ -6963,7 +7637,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -7092,7 +7766,7 @@ shelljs@0.7.6:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shelljs@^0.8.1:
+shelljs@^0.8.0, shelljs@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.1.tgz#729e038c413a2254c4078b95ed46e0397154a9f1"
   dependencies:
@@ -7132,7 +7806,7 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-slide@^1.1.3:
+slide@^1.1.3, slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
@@ -7210,6 +7884,12 @@ source-map-support@^0.4.15:
 source-map-support@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
+  dependencies:
+    source-map "^0.6.0"
+
+source-map-support@^0.5.3:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.4.tgz#54456efa89caa9270af7cd624cc2f123e51fbae8"
   dependencies:
     source-map "^0.6.0"
 
@@ -7400,6 +8080,10 @@ string-range@~1.2, string-range@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/string-range/-/string-range-1.2.2.tgz#a893ed347e72299bc83befbbf2a692a8d239d5dd"
 
+string-template@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -7408,7 +8092,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -7428,6 +8112,12 @@ string_decoder@~0.10.x:
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -7454,6 +8144,17 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
+strip-bom-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz#f87db5ef2613f6968aa545abfe1ec728b6a829ca"
+  dependencies:
+    first-chunk-stream "^2.0.0"
+    strip-bom "^2.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
@@ -7511,7 +8212,7 @@ supports-color@^4.0.0, supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.2.0:
+supports-color@^5.2.0, supports-color@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:
@@ -7532,6 +8233,10 @@ symbol-tree@^3.2.1, symbol-tree@^3.2.2:
 tapable@^0.2.5, tapable@^0.2.7, tapable@~0.2.5:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
+
+tapable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
 tape@2.3.0:
   version "2.3.0"
@@ -7567,6 +8272,13 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+temp@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
+  dependencies:
+    os-tmpdir "^1.0.0"
+    rimraf "~2.2.6"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -7586,6 +8298,14 @@ test-exclude@^4.1.1:
 text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+textextensions@2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.2.0.tgz#38ac676151285b658654581987a0ce1a4490d286"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -7623,6 +8343,12 @@ tmp@^0.0.29:
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
   dependencies:
     os-tmpdir "~1.0.1"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -7939,6 +8665,10 @@ underscore@1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -7968,6 +8698,10 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+untildify@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.2.tgz#7f1f302055b3fea0f3e81dc78eb36766cb65e3f1"
 
 unzip-response@^2.0.1:
   version "2.0.1"
@@ -8096,6 +8830,10 @@ uuid@^3.0.0, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
+v8-compile-cache@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz#8d32e4f16974654657e676e0e467a348e89b0dc4"
+
 v8flags@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
@@ -8132,6 +8870,36 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vinyl-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vinyl-file/-/vinyl-file-2.0.0.tgz#a7ebf5ffbefda1b7d18d140fcb07b223efb6751a"
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.3.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
+    strip-bom-stream "^2.0.0"
+    vinyl "^1.1.0"
+
+vinyl@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-1.2.0.tgz#5c88036cf565e5df05558bfc911f8656df218884"
+  dependencies:
+    clone "^1.0.0"
+    clone-stats "^0.0.1"
+    replace-ext "0.0.1"
+
+vinyl@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.1.0.tgz#021f9c2cf951d6b939943c89eb5ee5add4fd924c"
+  dependencies:
+    clone "^2.1.1"
+    clone-buffer "^1.0.0"
+    clone-stats "^1.0.0"
+    cloneable-readable "^1.0.0"
+    remove-trailing-separator "^1.0.1"
+    replace-ext "^1.0.0"
 
 vlq@^0.2.1:
   version "0.2.3"
@@ -8232,6 +9000,43 @@ webidl-conversions@^4.0.0, webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
+webpack-addons@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/webpack-addons/-/webpack-addons-1.1.5.tgz#2b178dfe873fb6e75e40a819fa5c26e4a9bc837a"
+  dependencies:
+    jscodeshift "^0.4.0"
+
+webpack-cli@^2.0.9:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-2.0.14.tgz#71d03d8c10547c1dfd674f71ff3b0457c33a74cd"
+  dependencies:
+    chalk "^2.3.2"
+    cross-spawn "^6.0.5"
+    diff "^3.5.0"
+    enhanced-resolve "^4.0.0"
+    envinfo "^4.4.2"
+    glob-all "^3.1.0"
+    global-modules "^1.0.0"
+    got "^8.2.0"
+    import-local "^1.0.0"
+    inquirer "^5.1.0"
+    interpret "^1.0.4"
+    jscodeshift "^0.5.0"
+    listr "^0.13.0"
+    loader-utils "^1.1.0"
+    lodash "^4.17.5"
+    log-symbols "^2.2.0"
+    mkdirp "^0.5.1"
+    p-each-series "^1.0.0"
+    p-lazy "^1.0.0"
+    prettier "^1.5.3"
+    supports-color "^5.3.0"
+    v8-compile-cache "^1.1.2"
+    webpack-addons "^1.1.5"
+    yargs "^11.1.0"
+    yeoman-environment "^2.0.0"
+    yeoman-generator "^2.0.3"
+
 webpack-sources@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
@@ -8265,7 +9070,7 @@ webpack@^2.7.0:
     webpack-sources "^1.0.1"
     yargs "^6.0.0"
 
-webpack@^3.10.0, webpack@^3.11.0:
+webpack@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.11.0.tgz#77da451b1d7b4b117adaf41a1a93b5742f24d894"
   dependencies:
@@ -8321,7 +9126,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
+which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
@@ -8381,6 +9186,14 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write-file-atomic@^1.2.0:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
 
 write-file-atomic@^2.0.0, write-file-atomic@^2.1.0:
   version "2.3.0"
@@ -8457,7 +9270,7 @@ xtend@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.2.0.tgz#eef6b1f198c1c8deafad8b1765a04dad4a01c5a9"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
@@ -8544,6 +9357,23 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
+yargs@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
+
 yargs@^6.0.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
@@ -8580,6 +9410,12 @@ yargs@^8.0.2:
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
 
+yargs@~1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.2.6.tgz#9c7b4a82fd5d595b2bf17ab6dcc43135432fe34b"
+  dependencies:
+    minimist "^0.1.0"
+
 yargs@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
@@ -8588,6 +9424,54 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yeoman-environment@^2.0.0, yeoman-environment@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-2.0.6.tgz#ae1b21d826b363f3d637f88a7fc9ea7414cb5377"
+  dependencies:
+    chalk "^2.1.0"
+    debug "^3.1.0"
+    diff "^3.3.1"
+    escape-string-regexp "^1.0.2"
+    globby "^6.1.0"
+    grouped-queue "^0.3.3"
+    inquirer "^3.3.0"
+    is-scoped "^1.0.0"
+    lodash "^4.17.4"
+    log-symbols "^2.1.0"
+    mem-fs "^1.1.0"
+    text-table "^0.2.0"
+    untildify "^3.0.2"
+
+yeoman-generator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/yeoman-generator/-/yeoman-generator-2.0.3.tgz#19426ed22687ffe05d31526c3f1c2cf67ba768f3"
+  dependencies:
+    async "^2.6.0"
+    chalk "^2.3.0"
+    cli-table "^0.3.1"
+    cross-spawn "^5.1.0"
+    dargs "^5.1.0"
+    dateformat "^3.0.2"
+    debug "^3.1.0"
+    detect-conflict "^1.0.0"
+    error "^7.0.2"
+    find-up "^2.1.0"
+    github-username "^4.0.0"
+    istextorbinary "^2.1.0"
+    lodash "^4.17.4"
+    make-dir "^1.1.0"
+    mem-fs-editor "^3.0.2"
+    minimist "^1.2.0"
+    pretty-bytes "^4.0.2"
+    read-chunk "^2.1.0"
+    read-pkg-up "^3.0.0"
+    rimraf "^2.6.2"
+    run-async "^2.0.0"
+    shelljs "^0.8.0"
+    text-table "^0.2.0"
+    through2 "^2.0.0"
+    yeoman-environment "^2.0.5"
 
 yn@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR introduces the following changes:

- Introduces wrappers for the `ERC721Receiver` and `MockERC721Receiver` contracts
- The former is used to enforce that addresses are valid recipients of 721 tokens, the latter is used in our test suite to test this functionality