### PR TITLE
Add TransferFrom tests for DebtTokenAPI

### DIFF
--- a/__test__/integration/debt_token_api/debt_token_api.spec.ts
+++ b/__test__/integration/debt_token_api/debt_token_api.spec.ts
@@ -11,6 +11,7 @@ import { DebtTokenScenarioRunner } from "./debt_token_scenario_runner";
 import {
     BALANCE_OF_SCENARIOS,
     OWNER_OF_SCENARIOS,
+    EXISTS_SCENARIOS,
     SUCCESSFUL_TRANSFER_FROM_SCENARIOS,
     UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS,
 } from "./scenarios";

--- a/__test__/integration/debt_token_api/debt_token_api.spec.ts
+++ b/__test__/integration/debt_token_api/debt_token_api.spec.ts
@@ -21,9 +21,13 @@ const web3 = new Web3(provider);
 const scenarioRunner = new DebtTokenScenarioRunner(web3);
 
 describe("Debt Token API (Integration Tests)", () => {
-    beforeEach(scenarioRunner.saveSnapshotAsync);
+    beforeEach(() => {
+        return scenarioRunner.saveSnapshotAsync();
+    });
 
-    afterEach(scenarioRunner.revertToSavedSnapshot);
+    afterEach(() => {
+        return scenarioRunner.revertToSavedSnapshot();
+    });
 
     describe("#balanceOf", () => {
         describe("debt token balances should be retrievable", () => {

--- a/__test__/integration/debt_token_api/debt_token_api.spec.ts
+++ b/__test__/integration/debt_token_api/debt_token_api.spec.ts
@@ -8,7 +8,12 @@ import * as Web3 from "web3";
 
 import { DebtTokenScenarioRunner } from "./debt_token_scenario_runner";
 
-import { BALANCE_OF_SCENARIOS, OWNER_OF_SCENARIOS, EXISTS_SCENARIOS } from "./scenarios";
+import {
+    BALANCE_OF_SCENARIOS,
+    OWNER_OF_SCENARIOS,
+    SUCCESSFUL_TRANSFER_FROM_SCENARIOS,
+    UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS,
+} from "./scenarios";
 
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
@@ -35,6 +40,16 @@ describe("Debt Token API (Integration Tests)", () => {
     describe("#exists", () => {
         describe("the existence of a given debt token id should be confirmable", () => {
             EXISTS_SCENARIOS.forEach(scenarioRunner.testExistsScenario);
+        });
+    });
+
+    describe("#transferFrom", () => {
+        describe("should fail", () => {
+            UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS.forEach(scenarioRunner.testTransferFromScenario);
+        });
+
+        describe("should succeed", () => {
+            SUCCESSFUL_TRANSFER_FROM_SCENARIOS.forEach(scenarioRunner.testTransferFromScenario);
         });
     });
 });

--- a/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
+++ b/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
@@ -7,8 +7,6 @@ import {
     BalanceOfScenarioRunner,
     ExistsScenarioRunner,
     TransferFromScenarioRunner,
-    TestAPIs,
-    TestAdapters,
 } from "./runners";
 
 // APIs
@@ -35,8 +33,6 @@ export class DebtTokenScenarioRunner {
     private existsScenarioRunner: ExistsScenarioRunner;
     private transferFromScenarioRunner: TransferFromScenarioRunner;
 
-    private currentSnapshotId: number;
-
     constructor(web3: Web3) {
         this.web3Utils = new Web3Utils(web3);
 
@@ -61,6 +57,11 @@ export class DebtTokenScenarioRunner {
         this.balanceOfScenarioRunner = new BalanceOfScenarioRunner(web3, testAPIs, testAdapters);
         this.ownerOfScenarioRunner = new OwnerOfScenarioRunner(web3, testAPIs, testAdapters);
         this.existsScenarioRunner = new ExistsScenarioRunner(web3, testAPIs, testAdapters);
+        this.transferFromScenarioRunner = new TransferFromScenarioRunner(
+            web3,
+            testAPIs,
+            testAdapters,
+        );
 
         this.testOwnerOfScenario = this.testOwnerOfScenario.bind(this);
         this.testBalanceOfScenario = this.testBalanceOfScenario.bind(this);
@@ -92,6 +93,8 @@ export class DebtTokenScenarioRunner {
     }
 
     public async revertToSavedSnapshot() {
-        await this.web3Utils.revertToSnapshot(this.currentSnapshotId);
+        if (this.currentSnapshotId) {
+            await this.web3Utils.revertToSnapshot(this.currentSnapshotId);
+        }
     }
 }

--- a/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
+++ b/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
@@ -25,6 +25,7 @@ import { Web3Utils } from "utils/web3_utils";
 export class DebtTokenScenarioRunner {
     // Snapshotting.
     private web3Utils: Web3Utils;
+
     private currentSnapshotId: number;
 
     // Scenario Runners

--- a/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
+++ b/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
@@ -6,6 +6,7 @@ import {
     OwnerOfScenarioRunner,
     BalanceOfScenarioRunner,
     ExistsScenarioRunner,
+    TransferFromScenarioRunner,
     TestAPIs,
     TestAdapters,
 } from "./runners";
@@ -32,6 +33,9 @@ export class DebtTokenScenarioRunner {
     private balanceOfScenarioRunner: BalanceOfScenarioRunner;
     private ownerOfScenarioRunner: OwnerOfScenarioRunner;
     private existsScenarioRunner: ExistsScenarioRunner;
+    private transferFromScenarioRunner: TransferFromScenarioRunner;
+
+    private currentSnapshotId: number;
 
     constructor(web3: Web3) {
         this.web3Utils = new Web3Utils(web3);
@@ -61,6 +65,7 @@ export class DebtTokenScenarioRunner {
         this.testOwnerOfScenario = this.testOwnerOfScenario.bind(this);
         this.testBalanceOfScenario = this.testBalanceOfScenario.bind(this);
         this.testExistsScenario = this.testExistsScenario.bind(this);
+        this.testTransferFromScenario = this.testTransferFromScenario.bind(this);
 
         this.saveSnapshotAsync = this.saveSnapshotAsync.bind(this);
         this.revertToSavedSnapshot = this.revertToSavedSnapshot.bind(this);
@@ -76,6 +81,10 @@ export class DebtTokenScenarioRunner {
 
     public async testExistsScenario(scenario: DebtTokenScenario.ExistsScenario) {
         return this.existsScenarioRunner.testScenario(scenario);
+    }
+
+    public async testTransferFromScenario(scenario: DebtTokenScenario.TransferFromScenario) {
+        return this.transferFromScenarioRunner.testScenario(scenario);
     }
 
     public async saveSnapshotAsync() {

--- a/__test__/integration/debt_token_api/runners/balance_of.ts
+++ b/__test__/integration/debt_token_api/runners/balance_of.ts
@@ -1,6 +1,3 @@
-// External
-import * as Web3 from "web3";
-
 // Types
 import { ScenarioRunner } from "./";
 import { DebtTokenScenario } from "../scenarios";
@@ -19,36 +16,6 @@ export class BalanceOfScenarioRunner extends ScenarioRunner {
                 const computedBalance = await debtTokenAPI.balanceOf(scenario.creditor);
                 expect(computedBalance.toNumber()).toEqual(scenario.balance);
             });
-        });
-    }
-
-    private async generateDebtTokenForOrder(
-        simpleInterestLoanOrder: SimpleInterestLoanOrder,
-        web3: Web3,
-        testAPIs: TestAPIs,
-        testAdapters: TestAdapters,
-    ) {
-        const { orderAPI, signerAPI, tokenAPI } = testAPIs;
-        const { simpleInterestLoanAdapter } = testAdapters;
-
-        const principalTokenAddress = await this.configureTokenBalance(
-            web3,
-            testAPIs,
-            simpleInterestLoanOrder.creditor,
-            simpleInterestLoanOrder.principalAmount,
-            simpleInterestLoanOrder.principalTokenSymbol,
-        );
-
-        await tokenAPI.setProxyAllowanceAsync(
-            principalTokenAddress,
-            simpleInterestLoanOrder.principalAmount,
-        );
-
-        const order = await orderAPI.generate(simpleInterestLoanAdapter, simpleInterestLoanOrder);
-        order.debtorSignature = await signerAPI.asDebtor(order, false);
-
-        await orderAPI.fillAsync(order, {
-            from: order.creditor,
         });
     }
 }

--- a/__test__/integration/debt_token_api/runners/index.ts
+++ b/__test__/integration/debt_token_api/runners/index.ts
@@ -5,7 +5,6 @@ import * as Web3 from "web3";
 // Types
 import { DebtTokenScenario } from "../scenarios";
 import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
-import { DebtOrder } from "src/types";
 
 // APIs
 import { ContractsAPI, DebtTokenAPI, OrderAPI, SignerAPI, TokenAPI } from "src/apis";

--- a/__test__/integration/debt_token_api/runners/index.ts
+++ b/__test__/integration/debt_token_api/runners/index.ts
@@ -107,3 +107,4 @@ export abstract class ScenarioRunner {
 export { BalanceOfScenarioRunner } from "./balance_of";
 export { OwnerOfScenarioRunner } from "./owner_of";
 export { ExistsScenarioRunner } from "./exists";
+export { TransferFromScenarioRunner } from "./transfer_from";

--- a/__test__/integration/debt_token_api/runners/transfer_from.ts
+++ b/__test__/integration/debt_token_api/runners/transfer_from.ts
@@ -1,50 +1,140 @@
 // External
-import * as Web3 from "web3";
 import { BigNumber } from "bignumber.js";
 
 // Types
-import { ScenarioRunner, TestAPIs, TestAdapters } from "./";
+import { ScenarioRunner } from "./";
 import { DebtTokenScenario } from "../scenarios";
 
+// Wrappers
+import { MockERC721ReceiverContract, TokenRegistryContract } from "src/wrappers";
+
+// Utils
+import { ACCOUNTS } from "../../../accounts";
+
+const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
+
 export class TransferFromScenarioRunner extends ScenarioRunner {
-    public testScenario(
-        scenario: DebtTokenScenario.TransferFromScenario,
-        web3: Web3,
-        testAPIs: TestAPIs,
-        testAdapters: TestAdapters,
-    ) {
-        const ARBITRARY_TOKEN_ID = new BigNumber(13);
+    public testScenario(scenario: DebtTokenScenario.TransferFromScenario) {
+        const NONEXISTENT_TOKEN_ID = new BigNumber(13);
+        const USER_RECIPIENT = ACCOUNTS[5].address;
 
-        const { debtTokenAPI } = testAPIs;
-        let tokenID: BigNumber;
+        const NON_CREDITOR_ADDRESS = ACCOUNTS[8].address;
+        const MALFORMED_TOKEN_RECIPIENT = "0x123";
 
+        let scenarioRecipient: string;
+        let recipientIsContract: boolean;
+        let erc721ReceiverContract: MockERC721ReceiverContract;
+
+        const { debtTokenAPI } = this.testAPIs;
+        let scenarioTokenID: BigNumber;
         let transferFromPromise: Promise<string>;
 
         describe(scenario.description, () => {
             beforeEach(async () => {
-                const issuanceHash = await this.generateDebtTokenForOrder(
-                    scenario.orders[0],
-                    web3,
-                    testAPIs,
-                    testAdapters,
+                erc721ReceiverContract = await MockERC721ReceiverContract.deployed(
+                    this.web3,
+                    TX_DEFAULTS,
+                );
+                const tokenRegistryContract = await TokenRegistryContract.deployed(
+                    this.web3,
+                    TX_DEFAULTS,
                 );
 
-                tokenID = new BigNumber(issuanceHash);
+                // Reset erc721Receiver contract so we can detect whether it's being called
+                await erc721ReceiverContract.reset.sendTransactionAsync();
+
+                // Contracts receiving transfers must implement the wallet interface...
+                const VALID_CONTRACT_RECIPIENT = erc721ReceiverContract.address;
+                // ...which the TokenRegistry contract does not
+                const INVALID_CONTRACT_RECIPIENT = tokenRegistryContract.address;
+
+                scenarioRecipient = scenario.to(
+                    USER_RECIPIENT,
+                    VALID_CONTRACT_RECIPIENT,
+                    INVALID_CONTRACT_RECIPIENT,
+                    MALFORMED_TOKEN_RECIPIENT,
+                );
+
+                let tokenIDs = [];
+
+                for (let i = 0; i < scenario.orders.length; i++) {
+                    const issuanceHash = await this.generateDebtTokenForOrder(scenario.orders[i]);
+
+                    tokenIDs.push(new BigNumber(issuanceHash));
+                }
+
+                const [creditorsTokenID, nonCreditorsTokenID] = tokenIDs;
+
+                // Transfer nonCreditorsToken to a different address
+                await debtTokenAPI.transferFrom(
+                    scenario.creditor,
+                    NON_CREDITOR_ADDRESS,
+                    nonCreditorsTokenID,
+                    "",
+                    { from: scenario.creditor },
+                );
+
+                // Set token approvals
+                await debtTokenAPI.approve(scenario.tokensApprovedOperator, creditorsTokenID, {
+                    from: scenario.creditor,
+                });
+
+                // Set owner's approvals
+                await debtTokenAPI.setApprovalForAll(scenario.ownersApprovedOperator, true);
+
+                scenarioTokenID = scenario.tokenID(
+                    creditorsTokenID,
+                    nonCreditorsTokenID,
+                    NONEXISTENT_TOKEN_ID,
+                );
+
+                // If the recipient is the MockERC721Recipient contract, we have to budget
+                // more gas to account for fees spent on recording the onERC721Received
+                // mock method call.  If the gas is left unspecified (i.e. null), the
+                // debtToken API will choose a default gas value for transferFrom
+                recipientIsContract =
+                    scenarioRecipient === VALID_CONTRACT_RECIPIENT ||
+                    scenarioRecipient === INVALID_CONTRACT_RECIPIENT;
+
+                // HACK: This is a temporary measure for dealing with discrepancies in gas costs
+                //       for different transferFrom calls (depending on how much gas the recipient contract
+                //       guzzles in the onER721Received method call).  A more permanent solution is tracked
+                //       in this Pivotal story: https://www.pivotaltracker.com/story/show/156644350
+                const transferFromGas = recipientIsContract ? 300000 : 200000;
 
                 transferFromPromise = debtTokenAPI.transferFrom(
                     scenario.from,
-                    scenario.to,
-                    scenario.tokenID(tokenID, ARBITRARY_TOKEN_ID),
+                    scenarioRecipient,
+                    scenarioTokenID,
                     scenario.data,
-                    scenario.options,
+                    {
+                        from: scenario.sender,
+                        gas: transferFromGas,
+                    },
                 );
+
+                if (scenario.succeeds) {
+                    await transferFromPromise;
+                }
             });
 
             if (scenario.succeeds) {
-                test(`token's owner has changed to ${scenario.to}`, async () => {
-                    await transferFromPromise;
+                test(`token's owner has changed to scenario's recipient`, async () => {
+                    await expect(debtTokenAPI.ownerOf(scenarioTokenID)).resolves.toEqual(
+                        scenarioRecipient,
+                    );
+                });
 
-                    await expect(debtTokenAPI.ownerOf(tokenID)).resolves.toEqual(scenario.to);
+                test("(if recipient is contract) onERC721Received method was called with correct data", async () => {
+                    if (recipientIsContract) {
+                        await expect(
+                            erc721ReceiverContract.wasOnERC721ReceivedCalledWith.callAsync(
+                                scenario.from,
+                                scenarioTokenID,
+                                scenario.data || "",
+                            ),
+                        ).resolves.toBeTruthy();
+                    }
                 });
             } else {
                 test(`throws ${scenario.errorType}`, async () => {

--- a/__test__/integration/debt_token_api/runners/transfer_from.ts
+++ b/__test__/integration/debt_token_api/runners/transfer_from.ts
@@ -1,0 +1,56 @@
+// External
+import * as Web3 from "web3";
+import { BigNumber } from "bignumber.js";
+
+// Types
+import { ScenarioRunner, TestAPIs, TestAdapters } from "./";
+import { DebtTokenScenario } from "../scenarios";
+
+export class TransferFromScenarioRunner extends ScenarioRunner {
+    public testScenario(
+        scenario: DebtTokenScenario.TransferFromScenario,
+        web3: Web3,
+        testAPIs: TestAPIs,
+        testAdapters: TestAdapters,
+    ) {
+        const ARBITRARY_TOKEN_ID = new BigNumber(13);
+
+        const { debtTokenAPI } = testAPIs;
+        let tokenID: BigNumber;
+
+        let transferFromPromise: Promise<string>;
+
+        describe(scenario.description, () => {
+            beforeEach(async () => {
+                const issuanceHash = await this.generateDebtTokenForOrder(
+                    scenario.orders[0],
+                    web3,
+                    testAPIs,
+                    testAdapters,
+                );
+
+                tokenID = new BigNumber(issuanceHash);
+
+                transferFromPromise = debtTokenAPI.transferFrom(
+                    scenario.from,
+                    scenario.to,
+                    scenario.tokenID(tokenID, ARBITRARY_TOKEN_ID),
+                    scenario.data,
+                    scenario.options,
+                );
+            });
+
+            if (scenario.succeeds) {
+                test(`token's owner has changed to ${scenario.to}`, async () => {
+                    await transferFromPromise;
+
+                    await expect(debtTokenAPI.ownerOf(tokenID)).resolves.toEqual(scenario.to);
+                });
+            } else {
+                test(`throws ${scenario.errorType}`, async () => {
+                    await expect(transferFromPromise).rejects.toThrow(scenario.errorMessage);
+                });
+            }
+        });
+    }
+}

--- a/__test__/integration/debt_token_api/scenarios/index.ts
+++ b/__test__/integration/debt_token_api/scenarios/index.ts
@@ -1,6 +1,6 @@
-import { DebtTokenScenario } from "./scenarios";
-import { BALANCE_OF_SCENARIOS } from "./balance_of";
-import { OWNER_OF_SCENARIOS } from "./owner_of";
-import { EXISTS_SCENARIOS } from "./exists";
-
-export { DebtTokenScenario, BALANCE_OF_SCENARIOS, OWNER_OF_SCENARIOS, EXISTS_SCENARIOS };
+export { DebtTokenScenario } from "./scenarios";
+export { BALANCE_OF_SCENARIOS } from "./balance_of";
+export { OWNER_OF_SCENARIOS } from "./owner_of";
+export { EXISTS_SCENARIOS } from "./exists";
+export { UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS } from "./unsuccessful_transfer_from";
+export { SUCCESSFUL_TRANSFER_FROM_SCENARIOS } from "./successful_transfer_from";

--- a/__test__/integration/debt_token_api/scenarios/scenarios.ts
+++ b/__test__/integration/debt_token_api/scenarios/scenarios.ts
@@ -25,8 +25,11 @@ export namespace DebtTokenScenario {
     export interface TransferFromScenario extends Scenario {
         from: string;
         to: string;
-        tokenID: BigNumber;
+        tokenID: (ordersIssuanceHash: BigNumber, other: BigNumber) => BigNumber;
         data?: string;
         options?: TxData;
+        succeeds: boolean;
+        errorType?: string;
+        errorMessage?: string;
     }
 }

--- a/__test__/integration/debt_token_api/scenarios/scenarios.ts
+++ b/__test__/integration/debt_token_api/scenarios/scenarios.ts
@@ -1,6 +1,5 @@
 import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
 import { BigNumber } from "bignumber.js";
-import { TxData } from "src/types";
 
 export namespace DebtTokenScenario {
     export interface Scenario {
@@ -23,11 +22,29 @@ export namespace DebtTokenScenario {
     }
 
     export interface TransferFromScenario extends Scenario {
+        // Setup arguments
+        tokensApprovedOperator: string;
+        ownersApprovedOperator: string;
+
+        // TransferFrom method arguments
         from: string;
-        to: string;
-        tokenID: (ordersIssuanceHash: BigNumber, other: BigNumber) => BigNumber;
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => string;
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            otherTokenId: BigNumber,
+            nonexistentTokenId: BigNumber,
+        ) => BigNumber;
         data?: string;
-        options?: TxData;
+
+        // Transaction options
+        sender: string;
+
+        // Scenario outcome
         succeeds: boolean;
         errorType?: string;
         errorMessage?: string;

--- a/__test__/integration/debt_token_api/scenarios/successful_transfer_from.ts
+++ b/__test__/integration/debt_token_api/scenarios/successful_transfer_from.ts
@@ -1,0 +1,47 @@
+// External
+import { BigNumber } from "bignumber.js";
+
+// Utils
+import * as Units from "utils/units";
+import { ERC20TokenSymbol } from "utils/constants";
+import { ACCOUNTS } from "../../../accounts";
+
+// Types
+import { DebtTokenScenario } from "./";
+import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
+
+const CREDITOR = ACCOUNTS[0].address;
+const DEBTOR = ACCOUNTS[1].address;
+const USER_RECIPIENT = ACCOUNTS[2].address;
+
+const order: SimpleInterestLoanOrder = {
+    principalAmount: Units.ether(10),
+    principalTokenSymbol: ERC20TokenSymbol.ZRX,
+    interestRate: new BigNumber(4.135),
+    amortizationUnit: "months",
+    termLength: new BigNumber(3),
+    debtor: DEBTOR,
+    creditor: CREDITOR,
+};
+
+const defaults: DebtTokenScenario.TransferFromScenario = {
+    // Scenario Setup Parameters
+    description: `Default Description`,
+    orders: [order],
+    debtor: DEBTOR,
+    creditor: CREDITOR,
+    succeeds: true,
+
+    // TransferFrom Scenario parameters
+    from: CREDITOR,
+    to: USER_RECIPIENT,
+    tokenID: (ordersIssuanceHash: BigNumber, other: BigNumber) => ordersIssuanceHash,
+    options: { from: CREDITOR },
+};
+
+export const SUCCESSFUL_TRANSFER_FROM_SCENARIOS: DebtTokenScenario.TransferFromScenario[] = [
+    {
+        ...defaults,
+        description: "called by tokens owner to a non-contract recipient",
+    },
+];

--- a/__test__/integration/debt_token_api/scenarios/successful_transfer_from.ts
+++ b/__test__/integration/debt_token_api/scenarios/successful_transfer_from.ts
@@ -12,9 +12,10 @@ import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapt
 
 const CREDITOR = ACCOUNTS[0].address;
 const DEBTOR = ACCOUNTS[1].address;
-const USER_RECIPIENT = ACCOUNTS[2].address;
+const TOKENS_APPROVED_OPERATOR = ACCOUNTS[2].address;
+const OWNERS_APPROVED_OPERATOR = ACCOUNTS[3].address;
 
-const order: SimpleInterestLoanOrder = {
+const ORDER_1: SimpleInterestLoanOrder = {
     principalAmount: Units.ether(10),
     principalTokenSymbol: ERC20TokenSymbol.ZRX,
     interestRate: new BigNumber(4.135),
@@ -24,24 +25,93 @@ const order: SimpleInterestLoanOrder = {
     creditor: CREDITOR,
 };
 
+const ORDER_2: SimpleInterestLoanOrder = {
+    principalAmount: new BigNumber(11 * 10 ** 18),
+    principalTokenSymbol: ERC20TokenSymbol.MKR,
+    interestRate: new BigNumber(8.937),
+    amortizationUnit: "years",
+    termLength: new BigNumber(2),
+    debtor: DEBTOR,
+    creditor: CREDITOR,
+};
+
 const defaults: DebtTokenScenario.TransferFromScenario = {
     // Scenario Setup Parameters
     description: `Default Description`,
-    orders: [order],
+    orders: [ORDER_1, ORDER_2],
     debtor: DEBTOR,
     creditor: CREDITOR,
     succeeds: true,
 
-    // TransferFrom Scenario parameters
+    // TransferFrom Setup Parameters
+    tokensApprovedOperator: TOKENS_APPROVED_OPERATOR,
+    ownersApprovedOperator: OWNERS_APPROVED_OPERATOR,
+
+    // TransferFrom Scenario Parameters
     from: CREDITOR,
-    to: USER_RECIPIENT,
-    tokenID: (ordersIssuanceHash: BigNumber, other: BigNumber) => ordersIssuanceHash,
-    options: { from: CREDITOR },
+    to: (
+        userRecipient: string,
+        validContractRecipient: string,
+        invalidContractRecipient: string,
+        malformed: string,
+    ) => userRecipient,
+    tokenID: (
+        ordersIssuanceHash: BigNumber,
+        otherTokenId: BigNumber,
+        nonexistentTokenId: BigNumber,
+    ) => ordersIssuanceHash,
+    sender: CREDITOR,
 };
 
 export const SUCCESSFUL_TRANSFER_FROM_SCENARIOS: DebtTokenScenario.TransferFromScenario[] = [
     {
         ...defaults,
         description: "called by tokens owner to a non-contract recipient",
+    },
+    {
+        ...defaults,
+        description:
+            "called by token's approved operator (i.e. `approve`) to a non-contract recipient",
+        sender: TOKENS_APPROVED_OPERATOR,
+    },
+    {
+        ...defaults,
+        description:
+            "called by token owner's approved operator (i.e. `setApprovalForAll`) to a non-contract recipient",
+        sender: OWNERS_APPROVED_OPERATOR,
+    },
+    {
+        ...defaults,
+        description: "called by tokens owner to a valid contract recipient",
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => validContractRecipient,
+    },
+    {
+        ...defaults,
+        description:
+            "called by token's approved operator (i.e. `approve`) to a valid contract recipient",
+        sender: TOKENS_APPROVED_OPERATOR,
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => validContractRecipient,
+    },
+    {
+        ...defaults,
+        description:
+            "called by token owner's approved operator (i.e. `setApprovalForAll`) to a valid contract recipient",
+        sender: OWNERS_APPROVED_OPERATOR,
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => validContractRecipient,
     },
 ];

--- a/__test__/integration/debt_token_api/scenarios/unsuccessful_transfer_from.ts
+++ b/__test__/integration/debt_token_api/scenarios/unsuccessful_transfer_from.ts
@@ -15,9 +15,11 @@ import { DebtTokenAPIErrors } from "src/apis/debt_token_api";
 
 const CREDITOR = ACCOUNTS[0].address;
 const DEBTOR = ACCOUNTS[1].address;
-const RECIPIENT = ACCOUNTS[2].address;
+const TOKENS_APPROVED_OPERATOR = ACCOUNTS[2].address;
+const OWNERS_APPROVED_OPERATOR = ACCOUNTS[3].address;
+const UNAPPROVED_TRANSFER_FROM_SENDER = ACCOUNTS[4].address;
 
-const order: SimpleInterestLoanOrder = {
+const ORDER_1: SimpleInterestLoanOrder = {
     principalAmount: Units.ether(10),
     principalTokenSymbol: ERC20TokenSymbol.ZRX,
     interestRate: new BigNumber(4.135),
@@ -27,27 +29,116 @@ const order: SimpleInterestLoanOrder = {
     creditor: CREDITOR,
 };
 
+const ORDER_2: SimpleInterestLoanOrder = {
+    principalAmount: new BigNumber(11 * 10 ** 18),
+    principalTokenSymbol: ERC20TokenSymbol.MKR,
+    interestRate: new BigNumber(8.937),
+    amortizationUnit: "years",
+    termLength: new BigNumber(2),
+    debtor: DEBTOR,
+    creditor: CREDITOR,
+};
+
 const defaults: DebtTokenScenario.TransferFromScenario = {
     // Scenario Setup Parameters
     description: `Default Description`,
-    orders: [order],
+    orders: [ORDER_1, ORDER_2],
     debtor: DEBTOR,
     creditor: CREDITOR,
     succeeds: false,
 
+    // TransferFrom Setup Parameters
+    tokensApprovedOperator: TOKENS_APPROVED_OPERATOR,
+    ownersApprovedOperator: OWNERS_APPROVED_OPERATOR,
+
     // TransferFrom Scenario parameters
     from: CREDITOR,
-    to: RECIPIENT,
-    tokenID: (ordersIssuanceHash: BigNumber, other: BigNumber) => ordersIssuanceHash,
-    data: "0x123456789abcdef",
+    to: (
+        userRecipient: string,
+        validContractRecipient: string,
+        invalidContractRecipient: string,
+        malformed: string,
+    ) => userRecipient,
+    tokenID: (
+        ordersIssuanceHash: BigNumber,
+        otherTokenId: BigNumber,
+        nonExistentTokenId: BigNumber,
+    ) => ordersIssuanceHash,
+    sender: CREDITOR,
 };
 
 export const UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS: DebtTokenScenario.TransferFromScenario[] = [
     {
         ...defaults,
+        description: "debt token does not exist",
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            nonCreditorsTokenID: BigNumber,
+            nonExistentTokenId: BigNumber,
+        ) => nonExistentTokenId,
+        errorType: "TOKEN_DOES_NOT_EXIST",
+        errorMessage: DebtTokenAPIErrors.TOKEN_DOES_NOT_EXIST(new BigNumber(13)),
+    },
+    {
+        ...defaults,
         description: "account being transferred from does not own debt token",
-        tokenID: (ordersIssuanceHash: BigNumber, other: BigNumber) => other,
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            nonCreditorsTokenID: BigNumber,
+            nonExistentTokenId: BigNumber,
+        ) => nonCreditorsTokenID,
         errorType: "TOKEN_DOES_NOT_BELONG_TO_ACCOUNT",
-        errorMessage: "Specified debt token does not belong to account",
+        errorMessage: DebtTokenAPIErrors.TOKEN_DOES_NOT_BELONG_TO_ACCOUNT(CREDITOR),
+    },
+    {
+        ...defaults,
+        description: "account sending transferFrom not approved to transfer debt token",
+        sender: UNAPPROVED_TRANSFER_FROM_SENDER,
+        errorType: "ACCOUNT_UNAUTHORIZED_TO_TRANSFER",
+        errorMessage: DebtTokenAPIErrors.ACCOUNT_UNAUTHORIZED_TO_TRANSFER(
+            UNAPPROVED_TRANSFER_FROM_SENDER,
+        ),
+    },
+    {
+        ...defaults,
+        description: "data field is non-hexadecimal",
+        data: "non-hexadecimal string",
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'instance does not match pattern "^0x[0-9a-fA-F]*$"',
+    },
+    {
+        ...defaults,
+        description: "from field is malformed",
+        from: "0x123",
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'instance does not match pattern "^0x[0-9a-fA-F]{40}$"',
+    },
+    {
+        ...defaults,
+        description: "to field is malformed",
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+            malformed: string,
+        ) => malformed,
+        errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+        errorMessage: 'instance does not match pattern "^0x[0-9a-fA-F]{40}$"',
+    },
+    {
+        ...defaults,
+        description: "recipient account is contract that does not implement ERC721Receiver",
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            nonCreditorsTokenID: BigNumber,
+            nonExistentTokenId: BigNumber,
+        ) => ordersIssuanceHash,
+        errorType: "CONTRACT_RECIPIENT_DOES_NOT_RECOGNIZE_721",
+        errorMessage: "does not implement the ERC721Receiver interface",
+        to: (
+            userRecipient: string,
+            validContractRecipient: string,
+            invalidContractRecipient: string,
+        ) => invalidContractRecipient,
     },
 ];

--- a/__test__/integration/debt_token_api/scenarios/unsuccessful_transfer_from.ts
+++ b/__test__/integration/debt_token_api/scenarios/unsuccessful_transfer_from.ts
@@ -1,0 +1,53 @@
+// External
+import { BigNumber } from "bignumber.js";
+
+// Utils
+import * as Units from "utils/units";
+import { ERC20TokenSymbol } from "utils/constants";
+import { ACCOUNTS } from "../../../accounts";
+
+// Types
+import { DebtTokenScenario } from "./";
+import { SimpleInterestLoanOrder } from "src/adapters/simple_interest_loan_adapter";
+
+// Errors
+import { DebtTokenAPIErrors } from "src/apis/debt_token_api";
+
+const CREDITOR = ACCOUNTS[0].address;
+const DEBTOR = ACCOUNTS[1].address;
+const RECIPIENT = ACCOUNTS[2].address;
+
+const order: SimpleInterestLoanOrder = {
+    principalAmount: Units.ether(10),
+    principalTokenSymbol: ERC20TokenSymbol.ZRX,
+    interestRate: new BigNumber(4.135),
+    amortizationUnit: "months",
+    termLength: new BigNumber(3),
+    debtor: DEBTOR,
+    creditor: CREDITOR,
+};
+
+const defaults: DebtTokenScenario.TransferFromScenario = {
+    // Scenario Setup Parameters
+    description: `Default Description`,
+    orders: [order],
+    debtor: DEBTOR,
+    creditor: CREDITOR,
+    succeeds: false,
+
+    // TransferFrom Scenario parameters
+    from: CREDITOR,
+    to: RECIPIENT,
+    tokenID: (ordersIssuanceHash: BigNumber, other: BigNumber) => ordersIssuanceHash,
+    data: "0x123456789abcdef",
+};
+
+export const UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS: DebtTokenScenario.TransferFromScenario[] = [
+    {
+        ...defaults,
+        description: "account being transferred from does not own debt token",
+        tokenID: (ordersIssuanceHash: BigNumber, other: BigNumber) => other,
+        errorType: "TOKEN_DOES_NOT_BELONG_TO_ACCOUNT",
+        errorMessage: "Specified debt token does not belong to account",
+    },
+];

--- a/src/invariants/debt_token.ts
+++ b/src/invariants/debt_token.ts
@@ -59,30 +59,6 @@ export class DebtTokenAssertions {
         }
     }
 
-    public async canBeTransferredByAccount(
-        debtTokenContract: DebtTokenContract,
-        tokenID: BigNumber,
-        account: string,
-        errorMessage: string,
-    ): Promise<void> {
-        // We include a try-catch here because the Zeppelin 721 implementation
-        // reverts on `ownerOf` if the token's owner is NULL_ADDRESS
-        try {
-            const tokenOwner = await debtTokenContract.ownerOf.callAsync(tokenID);
-            const tokensApprovedAddress = await debtTokenContract.getApproved.callAsync(tokenID);
-            const isApprovedForAll = await debtTokenContract.isApprovedForAll.callAsync(
-                tokenOwner,
-                account,
-            );
-
-            if (tokenOwner !== account && tokensApprovedAddress !== account && !isApprovedForAll) {
-                throw new Error(errorMessage);
-            }
-        } catch (e) {
-            throw new Error(errorMessage);
-        }
-    }
-
     public async canBeReceivedByAccountWithData(
         web3: Web3,
         tokenID: BigNumber,

--- a/src/invariants/debt_token.ts
+++ b/src/invariants/debt_token.ts
@@ -56,4 +56,28 @@ export class DebtTokenAssertions {
             throw new Error(errorMessage);
         }
     }
+
+    public async canBeTransferredByAccount(
+        debtTokenContract: DebtTokenContract,
+        tokenID: BigNumber,
+        account: string,
+        errorMessage: string,
+    ): Promise<void> {
+        // We include a try-catch here because the Zeppelin 721 implementation
+        // reverts on `ownerOf` if the token's owner is NULL_ADDRESS
+        try {
+            const tokenOwner = await debtTokenContract.ownerOf.callAsync(tokenID);
+            const tokensApprovedAddress = await debtTokenContract.getApproved.callAsync(tokenID);
+            const isApprovedForAll = await debtTokenContract.isApprovedForAll.callAsync(
+                tokenOwner,
+                account,
+            );
+
+            if (tokenOwner !== account && tokensApprovedAddress !== account && !isApprovedForAll) {
+                throw new Error(errorMessage);
+            }
+        } catch (e) {
+            throw new Error(errorMessage);
+        }
+    }
 }

--- a/src/invariants/debt_token.ts
+++ b/src/invariants/debt_token.ts
@@ -1,5 +1,7 @@
-import { DebtTokenContract } from "../wrappers";
+import { DebtTokenContract, ERC721ReceiverContract } from "../wrappers";
 import { BigNumber } from "bignumber.js";
+import * as Web3 from "web3";
+import { Web3Utils } from "utils/web3_utils";
 
 export class DebtTokenAssertions {
     public async exists(
@@ -78,6 +80,38 @@ export class DebtTokenAssertions {
             }
         } catch (e) {
             throw new Error(errorMessage);
+        }
+    }
+
+    public async canBeReceivedByAccountWithData(
+        web3: Web3,
+        tokenID: BigNumber,
+        recipient: string,
+        sender: string,
+        data: string = "",
+        errorMessage: string,
+    ): Promise<void> {
+        const utils = new Web3Utils(web3);
+        const isRecipientContract = await utils.doesContractExistAtAddressAsync(recipient);
+
+        // If a transfer recipient is a contract, it must implement the ERC721 Wallet interface
+        if (isRecipientContract) {
+            const EMPTY_TX_DEFAULTS = {};
+
+            const erc721Receiver = await ERC721ReceiverContract.at(
+                recipient,
+                web3,
+                EMPTY_TX_DEFAULTS,
+            );
+
+            // We check whether the recipient will accurately register a 721 interface
+            // by sending a message call to onERC721Received method (which is not mined)
+            // and seeing whether the call reverts.
+            try {
+                await erc721Receiver.onERC721Received.callAsync(sender, tokenID, data);
+            } catch (e) {
+                throw new Error(errorMessage);
+            }
         }
     }
 }

--- a/src/invariants/schema.ts
+++ b/src/invariants/schema.ts
@@ -31,6 +31,10 @@ export class SchemaAssertions {
         this.assertConformsToSchema(variableName, value, Schemas.bytes32Schema);
     }
 
+    public bytes(variableName: string, value: any) {
+        this.assertConformsToSchema(variableName, value, Schemas.bytesSchema);
+    }
+
     public number(variableName: string, value: any) {
         this.assertConformsToSchema(variableName, value, Schemas.numberSchema);
     }

--- a/src/schemas/basic_type_schemas.ts
+++ b/src/schemas/basic_type_schemas.ts
@@ -10,6 +10,12 @@ export const bytes32Schema = {
     pattern: "^0x[0-9a-fA-F]{64}$",
 };
 
+export const bytesSchema = {
+    id: "/Bytes",
+    type: "string",
+    pattern: "^0x[0-9a-fA-F]*$",
+};
+
 export const numberSchema = {
     id: "/Number",
     type: "object",

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -2,6 +2,7 @@ import {
     addressSchema,
     numberSchema,
     bytes32Schema,
+    bytesSchema,
     wholeNumberSchema,
 } from "./basic_type_schemas";
 import {
@@ -17,6 +18,7 @@ export const Schemas = {
     addressSchema,
     numberSchema,
     bytes32Schema,
+    bytesSchema,
     debtOrderSchema,
     debtOrderWithTermsSpecifiedSchema,
     debtOrderWithTermsAndDebtorSpecifiedSchema,

--- a/src/types/transaction_options.ts
+++ b/src/types/transaction_options.ts
@@ -4,6 +4,7 @@ import { Web3Utils } from "../../utils/web3_utils";
 
 export interface TxData {
     from?: string;
+    to?: string;
     gas?: number;
     gasPrice?: BigNumber;
     nonce?: number;

--- a/src/wrappers/contract_wrappers/base_contract_wrapper.ts
+++ b/src/wrappers/contract_wrappers/base_contract_wrapper.ts
@@ -3,17 +3,7 @@ import * as isUndefined from "lodash.isundefined";
 import { BigNumber } from "../../../utils/bignumber";
 import * as Web3 from "web3";
 import * as singleLineString from "single-line-string";
-
-export interface TxData {
-    from?: string;
-    gas?: number;
-    gasPrice?: BigNumber;
-    nonce?: number;
-}
-
-export interface TxDataPayable extends TxData {
-    value?: BigNumber;
-}
+import { TxData, TxDataPayable } from "src/types/";
 
 export const CONTRACT_WRAPPER_ERRORS = {
     CONTRACT_NOT_FOUND_ON_NETWORK: (contractName: string, networkId: number) =>

--- a/utils/transaction_utils.ts
+++ b/utils/transaction_utils.ts
@@ -1,0 +1,52 @@
+// External
+import * as Web3 from "web3";
+import * as ethjsABI from "ethjs-abi";
+import * as promisify from "tiny-promisify";
+
+// Types
+import { TxData } from "src/types";
+
+export namespace TransactionUtils {
+    function filterMethodABI(abi: any[]): Web3.MethodAbi[] {
+        return abi.filter((abiDef) => abiDef.type === "function");
+    }
+
+    function findMethod(
+        abi: Web3.AbiDefinition[],
+        name: string,
+        inputTypes: string,
+    ): Web3.MethodAbi {
+        const methodAbi = filterMethodABI(abi).find((abiDef) => {
+            const methodArgs = abiDef.inputs.map((input) => input.type).join(",");
+            return abiDef.name === name && methodArgs === inputTypes;
+        });
+
+        if (methodAbi) {
+            return methodAbi;
+        }
+
+        throw new Error(`Method: ${name} with input types: ${inputTypes} is not found`);
+    }
+
+    // sendTransaction is a util function to send a transaction to any overloaded
+    // method of a contract.
+    // Truffle contract instance cannot handle overloaded methods
+    // (truffle will only handle the first implementation of the method).
+    export async function sendRawTransaction(
+        web3: Web3,
+        web3ContractInstance: Web3.ContractInstance,
+        methodName: string,
+        inputTypes: string,
+        inputVals: any[],
+        txData: TxData = {},
+    ): Promise<string> {
+        const abiMethod = findMethod(web3ContractInstance.abi, methodName, inputTypes);
+        const encodedData = ethjsABI.encodeMethod(abiMethod, inputVals);
+
+        return promisify<string>(web3.eth.sendTransaction)({
+            data: encodedData,
+            ...txData,
+            to: web3ContractInstance.address,
+        });
+    }
+}


### PR DESCRIPTION
This PR introduces the following changes:

- Adds a suite of assertions into the DebtTokenAPI from `transferFrom` calls
- Adds a suite of tests to validate the above assertions are working correctly.