### PR TITLE
`notExpired` invariant assertion should use estimated next block time

### DIFF
--- a/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
+++ b/__test__/integration/debt_token_api/debt_token_scenario_runner.ts
@@ -63,7 +63,7 @@ export class DebtTokenScenarioRunner {
         };
 
         const testAdapters = {
-            simpleInterestLoanAdapter: new SimpleInterestLoanAdapter(contractsAPI),
+            simpleInterestLoanAdapter: new SimpleInterestLoanAdapter(web3, contractsAPI),
         };
 
         this.balanceOfScenarioRunner = new BalanceOfScenarioRunner(web3, testAPIs, testAdapters);

--- a/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
@@ -53,7 +53,7 @@ const collateralizedSimpleInterestLoanAdapter = new CollateralizedSimpleInterest
     web3,
     contracts,
 );
-const collateralizedLoanTerms = new CollateralizedLoanTerms(contracts);
+const collateralizedLoanTerms = new CollateralizedLoanTerms(web3, contracts);
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 

--- a/__test__/unit/adapters/simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/simple_interest_loan_adapter.spec.ts
@@ -34,8 +34,8 @@ const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const web3 = new Web3(provider);
 const web3Utils = new Web3Utils(web3);
 const contracts = new ContractsAPI(web3);
-const simpleInterestLoanAdapter = new SimpleInterestLoanAdapter(contracts);
-const simpleInterestLoanTerms = new SimpleInterestLoanTerms(contracts);
+const simpleInterestLoanAdapter = new SimpleInterestLoanAdapter(web3, contracts);
+const simpleInterestLoanTerms = new SimpleInterestLoanTerms(web3, contracts);
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 

--- a/__test__/unit/blockchain_api/error_scenario_runner.ts
+++ b/__test__/unit/blockchain_api/error_scenario_runner.ts
@@ -96,7 +96,7 @@ export class ErrorScenarioRunner {
         this.tokenTransferProxy = tokenTransferProxy;
         this.tokenRegistry = tokenRegistry;
 
-        this.simpleInterestLoan = new SimpleInterestLoanAdapter(this.contractsAPI);
+        this.simpleInterestLoan = new SimpleInterestLoanAdapter(this.web3, this.contractsAPI);
 
         // Mark instance as configured.
         this.isConfigured = true;

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -67,7 +67,7 @@ export const CollateralizerAdapterErrors = {
                          a CollateralizedSimpleInterestTermsContract.  As such, this adapter will
                          not interface with the terms contract as expected`,
     COLLATERAL_NOT_FOUND: (agreementId: string) =>
-        singleLineString`Collateral was not found for given agreement ID ${agreementId}. Make sure 
+        singleLineString`Collateral was not found for given agreement ID ${agreementId}. Make sure
                          that the agreement ID is correct, and that the collateral has not already
                          been withdrawn.`,
     DEBT_NOT_YET_REPAID: (agreementId: string) =>
@@ -80,8 +80,8 @@ export const CollateralizerAdapterErrors = {
 export class CollateralizedLoanTerms {
     private assert: Assertions;
 
-    constructor(contractsAPI: ContractsAPI) {
-        this.assert = new Assertions(contractsAPI);
+    constructor(web3: Web3, contractsAPI: ContractsAPI) {
+        this.assert = new Assertions(web3, contractsAPI);
     }
 
     public packParameters(params: CollateralizedTermsContractParameters): string {
@@ -177,13 +177,13 @@ export class CollateralizedSimpleInterestLoanAdapter implements Adapter.Interfac
     private web3Utils: Web3Utils;
 
     public constructor(web3: Web3, contractsAPI: ContractsAPI) {
-        this.assert = new Assertions(contractsAPI);
+        this.assert = new Assertions(web3, contractsAPI);
         this.web3Utils = new Web3Utils(web3);
 
         this.contractsAPI = contractsAPI;
 
-        this.simpleInterestLoanTerms = new SimpleInterestLoanTerms(contractsAPI);
-        this.collateralizedLoanTerms = new CollateralizedLoanTerms(contractsAPI);
+        this.simpleInterestLoanTerms = new SimpleInterestLoanTerms(web3, contractsAPI);
+        this.collateralizedLoanTerms = new CollateralizedLoanTerms(web3, contractsAPI);
     }
 
     public async toDebtOrder(

--- a/src/adapters/simple_interest_loan_adapter.ts
+++ b/src/adapters/simple_interest_loan_adapter.ts
@@ -1,6 +1,7 @@
 // libraries
 import * as singleLineString from "single-line-string";
 import * as omit from "lodash.omit";
+import * as Web3 from "web3";
 
 // utils
 import { BigNumber } from "../../utils/bignumber";
@@ -88,8 +89,8 @@ export const SimpleInterestAdapterErrors = {
 export class SimpleInterestLoanTerms {
     private assert: Assertions;
 
-    constructor(contracts: ContractsAPI) {
-        this.assert = new Assertions(contracts);
+    constructor(web3: Web3, contracts: ContractsAPI) {
+        this.assert = new Assertions(web3, contracts);
     }
 
     public packParameters(termsContractParameters: SimpleInterestTermsContractParameters): string {
@@ -233,10 +234,10 @@ export class SimpleInterestLoanAdapter implements Adapter.Interface {
     private contracts: ContractsAPI;
     private termsContractInterface: SimpleInterestLoanTerms;
 
-    public constructor(contracts: ContractsAPI) {
-        this.assert = new Assertions(contracts);
+    public constructor(web3: Web3, contracts: ContractsAPI) {
+        this.assert = new Assertions(web3, contracts);
         this.contracts = contracts;
-        this.termsContractInterface = new SimpleInterestLoanTerms(contracts);
+        this.termsContractInterface = new SimpleInterestLoanTerms(web3, contracts);
     }
 
     /**

--- a/src/apis/adapters_api.ts
+++ b/src/apis/adapters_api.ts
@@ -50,7 +50,7 @@ export class AdaptersAPI {
     constructor(web3: Web3, contractsApi: ContractsAPI) {
         this.contracts = contractsApi;
 
-        this.simpleInterestLoan = new SimpleInterestLoanAdapter(this.contracts);
+        this.simpleInterestLoan = new SimpleInterestLoanAdapter(web3, this.contracts);
         this.collateralizedSimpleInterestLoan = new CollateralizedSimpleInterestLoanAdapter(
             web3,
             this.contracts,

--- a/src/apis/blockchain_api.ts
+++ b/src/apis/blockchain_api.ts
@@ -27,7 +27,7 @@ export class BlockchainAPI {
     constructor(web3: Web3, contracts: ContractsAPI) {
         this.web3Utils = new Web3Utils(web3);
         this.intervalManager = new IntervalManager();
-        this.assert = new Assertions(contracts);
+        this.assert = new Assertions(web3, contracts);
         this.contracts = contracts;
 
         // We need to configure the ABI Decoder in order to pull out relevant logs.

--- a/src/apis/debt_token_api.ts
+++ b/src/apis/debt_token_api.ts
@@ -63,7 +63,7 @@ export class DebtTokenAPI implements ERC721 {
     constructor(web3: Web3, contracts: ContractsAPI) {
         this.web3 = web3;
         this.contracts = contracts;
-        this.assert = new Assertions(this.contracts);
+        this.assert = new Assertions(web3, this.contracts);
     }
 
     public async balanceOf(owner: string): Promise<BigNumber> {

--- a/src/apis/order_api.ts
+++ b/src/apis/order_api.ts
@@ -93,7 +93,7 @@ export class OrderAPI {
         this.contracts = contracts;
         this.adapters = adapters;
 
-        this.assert = new Assertions(this.contracts);
+        this.assert = new Assertions(web3, this.contracts);
     }
 
     /**
@@ -317,7 +317,8 @@ export class OrderAPI {
         this.assert.order.validUnderwriterFee(debtOrder, OrderAPIErrors.INVALID_UNDERWRITER_FEE());
         this.assert.order.validRelayerFee(debtOrder, OrderAPIErrors.INVALID_RELAYER_FEE());
         this.assert.order.validFees(debtOrder, OrderAPIErrors.INVALID_FEES());
-        this.assert.order.notExpired(debtOrder, OrderAPIErrors.EXPIRED());
+
+        await this.assert.order.notExpired(debtOrder, OrderAPIErrors.EXPIRED());
 
         await this.assert.order.debtOrderNotCancelledAsync(
             debtOrder,

--- a/src/apis/servicing_api.ts
+++ b/src/apis/servicing_api.ts
@@ -258,7 +258,7 @@ export class ServicingAPI {
 
         switch (termsContractType) {
             case "SimpleInterestTermsContractContract":
-                return new SimpleInterestLoanAdapter(this.contracts);
+                return new SimpleInterestLoanAdapter(this.web3, this.contracts);
         }
 
         throw new Error(ServicingAPIErrors.UNKNOWN_LOAN_ADAPTER(termsContract));

--- a/src/apis/signer_api.ts
+++ b/src/apis/signer_api.ts
@@ -27,7 +27,7 @@ export class SignerAPI {
     constructor(web3: Web3, contracts: ContractsAPI) {
         this.web3 = web3;
         this.contracts = contracts;
-        this.assert = new Assertions(this.contracts);
+        this.assert = new Assertions(this.web3, this.contracts);
     }
 
     /**

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -25,7 +25,7 @@ export class TokenAPI {
     constructor(web3: Web3, contracts: ContractsAPI) {
         this.web3 = web3;
         this.contracts = contracts;
-        this.assert = new Assertions(this.contracts);
+        this.assert = new Assertions(this.web3, this.contracts);
     }
 
     /**

--- a/src/invariants/index.ts
+++ b/src/invariants/index.ts
@@ -1,3 +1,6 @@
+// External
+import * as Web3 from "web3";
+
 // Assertions
 import { AccountAssertions } from "./account";
 import { AdapterAssertions } from "./adapter";
@@ -21,12 +24,12 @@ export class Assertions {
 
     private contracts: ContractsAPI;
 
-    public constructor(contracts: ContractsAPI) {
+    public constructor(web3: Web3, contracts: ContractsAPI) {
         this.contracts = contracts;
 
         this.account = new AccountAssertions();
         this.adapter = new AdapterAssertions();
-        this.order = new OrderAssertions(this.contracts);
+        this.order = new OrderAssertions(web3, this.contracts);
         this.token = new TokenAssertions();
         this.schema = new SchemaAssertions();
         this.debtToken = new DebtTokenAssertions();


### PR DESCRIPTION
This PR introduces the following changes:

- modify the `notExpired` invariant in the order assertions to check whether an order is expired using the estimated time of the block in which it would be mined (as opposed to the current unix time)