### PR TITLE
Add error scenarios for `getApproved`

### DIFF
--- a/__test__/integration/debt_token_api/debt_token_api.spec.ts
+++ b/__test__/integration/debt_token_api/debt_token_api.spec.ts
@@ -18,7 +18,7 @@ import {
     UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS,
     SUCCESSFUL_APPROVE_SCENARIOS,
     UNSUCCESSFUL_APPROVE_SCENARIOS,
-    GET_APPROVED_SCENARIOS,
+    GetApprovedScenarios,
     SET_APPROVAL_FOR_ALL_SCENARIOS,
     IS_APPROVED_FOR_ALL_SCENARIOS,
 } from "./scenarios";
@@ -86,8 +86,12 @@ describe("Debt Token API (Integration Tests)", () => {
     });
 
     describe("#getApproved", () => {
-        describe("approved accounts for a debt token should be retrievable", () => {
-            GET_APPROVED_SCENARIOS.forEach(scenarioRunner.testGetApprovedScenario);
+        describe("should succeed", () => {
+            GetApprovedScenarios.SUCCESSFUL.forEach(scenarioRunner.testGetApprovedScenario);
+        });
+
+        describe("should fail", () => {
+            GetApprovedScenarios.UNSUCCESSFUL.forEach(scenarioRunner.testGetApprovedScenario);
         });
     });
 

--- a/__test__/integration/debt_token_api/runners/index.ts
+++ b/__test__/integration/debt_token_api/runners/index.ts
@@ -63,6 +63,9 @@ export abstract class ScenarioRunner {
         await tokenAPI.setProxyAllowanceAsync(
             principalToken.address,
             simpleInterestLoanOrder.principalAmount,
+            {
+                from: simpleInterestLoanOrder.creditor,
+            },
         );
 
         const order = await orderAPI.generate(simpleInterestLoanAdapter, simpleInterestLoanOrder);

--- a/__test__/integration/debt_token_api/scenarios/get_approved.ts
+++ b/__test__/integration/debt_token_api/scenarios/get_approved.ts
@@ -1,17 +1,63 @@
 import { DebtTokenScenario } from "./scenarios";
 import { Orders } from "./orders";
+import { DebtTokenAPIErrors } from "src/apis/debt_token_api";
 
-export const GET_APPROVED_SCENARIOS: DebtTokenScenario.GetApprovedScenario[] = [
-    {
-        description: "debt token specifies an approved account",
-        orders: Orders.ALL_ORDERS,
-        ...Orders.WHO,
-        isApproved: true,
-    },
-    {
-        description: "debt token does not specify an approved account",
-        orders: Orders.ALL_ORDERS,
-        ...Orders.WHO,
-        isApproved: false,
-    },
-];
+const defaults = {
+    orderFilledByCreditorOne: Orders.CREDITOR_ONE_ORDER,
+    orderFilledByCreditorTwo: Orders.CREDITOR_TWO_ORDER,
+    tokenID: (creditorOneTokenID, creditorTwoTokenID, nonexistentTokenID, malFormedTokenID) =>
+        creditorOneTokenID,
+    approvee: Orders.APPROVEE,
+};
+
+const successfulDefaults = {
+    ...defaults,
+    shouldSucceed: true,
+};
+
+const unsuccessfulDefaults = {
+    ...defaults,
+    shouldSucceed: false,
+    isApproved: false,
+};
+
+export namespace GetApprovedScenarios {
+    export const SUCCESSFUL: DebtTokenScenario.GetApprovedScenario[] = [
+        {
+            description: "debt token specifies an approved account",
+            ...successfulDefaults,
+            isApproved: true,
+        },
+        {
+            description: "debt token does not specify an approved account",
+            ...successfulDefaults,
+            isApproved: false,
+        },
+    ];
+    export const UNSUCCESSFUL: DebtTokenScenario.GetApprovedScenario[] = [
+        {
+            description: "debt token does not exist",
+            ...unsuccessfulDefaults,
+            tokenID: (
+                creditorOneTokenID,
+                creditorTwoTokenID,
+                nonexistentTokenID,
+                malFormedTokenID,
+            ) => nonexistentTokenID,
+            errorType: "TOKEN_WITH_ID_DOES_NOT_EXIST",
+            errorMessage: DebtTokenAPIErrors.TOKEN_WITH_ID_DOES_NOT_EXIST(),
+        },
+        {
+            description: "debt token id is malformed",
+            ...unsuccessfulDefaults,
+            tokenID: (
+                creditorOneTokenID,
+                creditorTwoTokenID,
+                nonexistentTokenID,
+                malFormedTokenID,
+            ) => malFormedTokenID,
+            errorType: "DOES_NOT_CONFORM_TO_SCHEMA",
+            errorMessage: /instance does not conform to the "wholeBigNumber" format/,
+        },
+    ];
+}

--- a/__test__/integration/debt_token_api/scenarios/index.ts
+++ b/__test__/integration/debt_token_api/scenarios/index.ts
@@ -8,6 +8,6 @@ export {
     UNSUCCESSFUL_TRANSFER_FROM_SCENARIOS,
 } from "./transfer_from";
 export { SUCCESSFUL_APPROVE_SCENARIOS, UNSUCCESSFUL_APPROVE_SCENARIOS } from "./approve";
-export { GET_APPROVED_SCENARIOS } from "./get_approved";
+export { GetApprovedScenarios } from "./get_approved";
 export { SET_APPROVAL_FOR_ALL_SCENARIOS } from "./set_approval_for_all";
 export { IS_APPROVED_FOR_ALL_SCENARIOS } from "./is_approved_for_all";

--- a/__test__/integration/debt_token_api/scenarios/orders.ts
+++ b/__test__/integration/debt_token_api/scenarios/orders.ts
@@ -4,9 +4,11 @@ import { BigNumber } from "bignumber.js";
 import { ERC20TokenSymbol } from "utils/constants";
 
 export namespace Orders {
+    export const NONEXISTENT_TOKEN_ID = new BigNumber(13);
+    export const MALFORMED_TOKEN_ID = new BigNumber(-5);
+
     export const CREDITOR = ACCOUNTS[0].address;
     export const DEBTOR = ACCOUNTS[1].address;
-    export const APPROVED = ACCOUNTS[2].address;
 
     export const WHO = {
         creditor: CREDITOR,
@@ -41,4 +43,28 @@ export namespace Orders {
     };
 
     export const ALL_ORDERS = [ORDER_ONE, ORDER_TWO, ORDER_THREE];
+
+    export const CREDITOR_ONE = ACCOUNTS[5].address;
+    export const CREDITOR_TWO = ACCOUNTS[6].address;
+    export const APPROVEE = ACCOUNTS[7].address;
+
+    export const CREDITOR_ONE_ORDER: SimpleInterestLoanOrder = {
+        principalAmount: new BigNumber(15 * 10 ** 18),
+        principalTokenSymbol: ERC20TokenSymbol.ZRX,
+        interestRate: new BigNumber(4.135),
+        amortizationUnit: "months",
+        termLength: new BigNumber(14),
+        creditor: CREDITOR_ONE,
+        debtor: DEBTOR,
+    };
+
+    export const CREDITOR_TWO_ORDER: SimpleInterestLoanOrder = {
+        principalAmount: new BigNumber(3 * 10 ** 18),
+        principalTokenSymbol: ERC20TokenSymbol.REP,
+        interestRate: new BigNumber(4.325),
+        amortizationUnit: "months",
+        termLength: new BigNumber(5),
+        creditor: CREDITOR_TWO,
+        debtor: DEBTOR,
+    };
 }

--- a/__test__/integration/debt_token_api/scenarios/orders.ts
+++ b/__test__/integration/debt_token_api/scenarios/orders.ts
@@ -49,22 +49,12 @@ export namespace Orders {
     export const APPROVEE = ACCOUNTS[7].address;
 
     export const CREDITOR_ONE_ORDER: SimpleInterestLoanOrder = {
-        principalAmount: new BigNumber(15 * 10 ** 18),
-        principalTokenSymbol: ERC20TokenSymbol.ZRX,
-        interestRate: new BigNumber(4.135),
-        amortizationUnit: "months",
-        termLength: new BigNumber(14),
+        ...ORDER_ONE,
         creditor: CREDITOR_ONE,
-        debtor: DEBTOR,
     };
 
     export const CREDITOR_TWO_ORDER: SimpleInterestLoanOrder = {
-        principalAmount: new BigNumber(3 * 10 ** 18),
-        principalTokenSymbol: ERC20TokenSymbol.REP,
-        interestRate: new BigNumber(4.325),
-        amortizationUnit: "months",
-        termLength: new BigNumber(5),
+        ...ORDER_TWO,
         creditor: CREDITOR_TWO,
-        debtor: DEBTOR,
     };
 }

--- a/__test__/integration/debt_token_api/scenarios/scenarios.ts
+++ b/__test__/integration/debt_token_api/scenarios/scenarios.ts
@@ -19,10 +19,13 @@ export namespace DebtTokenScenario {
     }
 
     export interface Tokenizable {
+        orderFilledByCreditorOne: SimpleInterestLoanOrder;
+        orderFilledByCreditorTwo: SimpleInterestLoanOrder;
         tokenID: (
-            ordersIssuanceHash: BigNumber,
-            otherTokenId: BigNumber,
-            nonexistentTokenId: BigNumber,
+            creditorOneTokenID: BigNumber,
+            creditorTwoTokenID: BigNumber,
+            nonexistentTokenID: BigNumber,
+            malFormedTokenID: BigNumber,
         ) => BigNumber;
     }
 

--- a/__test__/integration/debt_token_api/scenarios/scenarios.ts
+++ b/__test__/integration/debt_token_api/scenarios/scenarios.ts
@@ -49,8 +49,9 @@ export namespace DebtTokenScenario {
         approvee: string;
     }
 
-    export interface GetApprovedScenario extends Scenario {
+    export interface GetApprovedScenario extends BaseScenario, Throwable, Tokenizable {
         isApproved: boolean;
+        approvee: string;
     }
 
     export interface SetApprovalForAllScenario extends BaseScenario, Throwable {

--- a/__test__/integration/debt_token_api/scenarios/scenarios.ts
+++ b/__test__/integration/debt_token_api/scenarios/scenarios.ts
@@ -18,6 +18,14 @@ export namespace DebtTokenScenario {
         errorMessage?: string;
     }
 
+    export interface Tokenizable {
+        tokenID: (
+            ordersIssuanceHash: BigNumber,
+            otherTokenId: BigNumber,
+            nonexistentTokenId: BigNumber,
+        ) => BigNumber;
+    }
+
     export interface ThrowableScenario extends Scenario, Throwable {}
 
     export interface BalanceOfScenario extends Scenario {


### PR DESCRIPTION
This PR introduces the `Tokenizable` interface which allows us to inject token IDs into our scenarios to simulate various errors.