### PR TITLE
Bump version to 0.0.37 and add prepublish build script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharmaprotocol/dharma.js",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
         "commitmsg": "commitlint -e $GIT_PARAMS",
         "prettify": "prettier --write {src,__test__,__mocks__}/**/*.ts"
     },
+    "prepublishOnly": [
+        "build"
+    ],
     "lint-staged": {
         "{src,__test__,__mocks__}/**/*.ts": [
             "prettier --write"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dharmaprotocol/dharma.js",
-    "version": "0.0.36",
+    "version": "0.0.37",
     "description": "",
     "keywords": [],
     "main": "dist/dharma.umd.js",


### PR DESCRIPTION
This PR introduces the following changes:

- bumps package version to 0.0.37
- Introduces prepublish script that automatically runs "build"