### PR TITLE
build: add prepublish script in the correct location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharmaprotocol/dharma.js",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharmaprotocol/dharma.js",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharmaprotocol/dharma.js",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharmaprotocol/dharma.js",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,10 @@
         "semantic-release": "semantic-release pre && npm publish && semantic-release post",
         "semantic-release-prepare": "ts-node tools/semantic-release-prepare",
         "precommit": "lint-staged",
+        "prepublishOnly": "npm run build",
         "commitmsg": "commitlint -e $GIT_PARAMS",
         "prettify": "prettier --write {src,__test__,__mocks__}/**/*.ts"
     },
-    "prepare": [
-        "build"
-    ],
     "lint-staged": {
         "{src,__test__,__mocks__}/**/*.ts": [
             "prettier --write"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dharmaprotocol/dharma.js",
-    "version": "0.0.39",
+    "version": "0.0.40",
     "description": "",
     "keywords": [],
     "main": "dist/dharma.umd.js",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "commitmsg": "commitlint -e $GIT_PARAMS",
         "prettify": "prettier --write {src,__test__,__mocks__}/**/*.ts"
     },
-    "prepublishOnly": [
+    "prepare": [
         "build"
     ],
     "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
         "commitmsg": "commitlint -e $GIT_PARAMS",
         "prettify": "prettier --write {src,__test__,__mocks__}/**/*.ts"
     },
+    "prepublishOnly": [
+        "build"
+    ],
     "lint-staged": {
         "{src,__test__,__mocks__}/**/*.ts": [
             "prettier --write"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dharmaprotocol/dharma.js",
-    "version": "0.0.36",
+    "version": "0.0.37",
     "description": "",
     "keywords": [],
     "main": "dist/dharma.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dharmaprotocol/dharma.js",
-    "version": "0.0.37",
+    "version": "0.0.38",
     "description": "",
     "keywords": [],
     "main": "dist/dharma.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dharmaprotocol/dharma.js",
-    "version": "0.0.38",
+    "version": "0.0.39",
     "description": "",
     "keywords": [],
     "main": "dist/dharma.umd.js",


### PR DESCRIPTION
This PR introduces the following changes:

- after various failed attempts, managed to figure out how to trigger an `npm build` command to run before any `npm publish` command.
