### PR TITLE
build: remove object-literal-sort-keys rule in tslint

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -2,6 +2,7 @@
     "extends": ["tslint:latest"],
     "rules": {
         "no-implicit-dependencies": false,
-        "object-literal-sort-keys": false
+        "object-literal-sort-keys": false,
+        "interface-name": false
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": ["tslint:latest"],
     "rules": {
-        "no-implicit-dependencies": false
+        "no-implicit-dependencies": false,
+        "object-literal-sort-keys": false
     }
 }


### PR DESCRIPTION
I'm proposing we remove this rule, since most of our code already doesn't comply with it.