### PR TITLE
feat: return more info in tokens list

### DIFF
--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -499,7 +499,12 @@ describe("Token API (Integration Tests)", () => {
             test("should return the list of token symbols and names", async () => {
                 const tokenSymbolList = await tokenApi.getSupportedTokens();
                 const expectedTokenSymbolList = TOKEN_REGISTRY_TRACKED_TOKENS.map((token) => {
-                    return { symbol: token.symbol, name: token.name };
+                    return {
+                        address: token.address,
+                        symbol: token.symbol,
+                        name: token.name,
+                        numDecimals: token.decimals,
+                    };
                 });
 
                 expect(_.sortBy(tokenSymbolList, "symbol")).toEqual(

--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -508,4 +508,17 @@ describe("Token API (Integration Tests)", () => {
             });
         });
     });
+
+    describe("#getTokenSymbolList", () => {
+        describe("token registry has tokens", () => {
+            test("should return the list of token symbols", async () => {
+                const tokenSymbolList = await tokenApi.getTokenSymbolList();
+                const expectedTokenSymbolList = TOKEN_REGISTRY_TRACKED_TOKENS.map(
+                    (token) => token.symbol,
+                );
+
+                expect(tokenSymbolList.sort()).toEqual(expectedTokenSymbolList.sort());
+            });
+        });
+    });
 });

--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -3,6 +3,7 @@ import * as ABIDecoder from "abi-decoder";
 import * as compact from "lodash.compact";
 import * as Web3 from "web3";
 import { BigNumber } from "../../utils/bignumber";
+import * as _ from "lodash";
 
 // utils
 import { TOKEN_REGISTRY_TRACKED_TOKENS } from "../../utils/constants";
@@ -493,15 +494,21 @@ describe("Token API (Integration Tests)", () => {
         });
     });
 
-    describe("#getTokenSymbolList", () => {
+    describe("#getSupportedTokens", () => {
         describe("token registry has tokens", () => {
-            test("should return the list of token symbols", async () => {
-                const tokenSymbolList = await tokenApi.getTokenSymbolList();
+            test("should return the list of token symbols and names", async () => {
+                const tokenSymbolList = await tokenApi.getSupportedTokens();
                 const expectedTokenSymbolList = TOKEN_REGISTRY_TRACKED_TOKENS.map(
-                    (token) => token.symbol,
+                    (token) => {
+                        return { symbol: token.symbol, name: token.name };
+                    },
                 );
 
-                expect(tokenSymbolList.sort()).toEqual(expectedTokenSymbolList.sort());
+                expect(
+                    _.sortBy(tokenSymbolList, "symbol"),
+                ).toEqual(
+                    _.sortBy(expectedTokenSymbolList, "symbol"),
+                );
             });
         });
     });

--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -1,9 +1,9 @@
 // libraries
 import * as ABIDecoder from "abi-decoder";
+import * as _ from "lodash";
 import * as compact from "lodash.compact";
 import * as Web3 from "web3";
 import { BigNumber } from "../../utils/bignumber";
-import * as _ from "lodash";
 
 // utils
 import { TOKEN_REGISTRY_TRACKED_TOKENS } from "../../utils/constants";
@@ -498,15 +498,11 @@ describe("Token API (Integration Tests)", () => {
         describe("token registry has tokens", () => {
             test("should return the list of token symbols and names", async () => {
                 const tokenSymbolList = await tokenApi.getSupportedTokens();
-                const expectedTokenSymbolList = TOKEN_REGISTRY_TRACKED_TOKENS.map(
-                    (token) => {
-                        return { symbol: token.symbol, name: token.name };
-                    },
-                );
+                const expectedTokenSymbolList = TOKEN_REGISTRY_TRACKED_TOKENS.map((token) => {
+                    return { symbol: token.symbol, name: token.name };
+                });
 
-                expect(
-                    _.sortBy(tokenSymbolList, "symbol"),
-                ).toEqual(
+                expect(_.sortBy(tokenSymbolList, "symbol")).toEqual(
                     _.sortBy(expectedTokenSymbolList, "symbol"),
                 );
             });

--- a/__test__/integration/token_api.spec.ts
+++ b/__test__/integration/token_api.spec.ts
@@ -1,14 +1,17 @@
-// libraries
+// External Libraries
 import * as ABIDecoder from "abi-decoder";
 import * as _ from "lodash";
 import * as compact from "lodash.compact";
 import * as Web3 from "web3";
-import { BigNumber } from "../../utils/bignumber";
 
-// utils
+// Utils
+import { BigNumber } from "../../utils/bignumber";
 import { TOKEN_REGISTRY_TRACKED_TOKENS } from "../../utils/constants";
 import * as Units from "../../utils/units";
 import { Web3Utils } from "../../utils/web3_utils";
+
+// Test Utils
+import { isNonNullAddress } from "../utils/utils";
 
 import { ContractsAPI, TokenAPI } from "../../src/apis";
 import { TokenAPIErrors } from "../../src/apis/token_api";
@@ -497,19 +500,33 @@ describe("Token API (Integration Tests)", () => {
     describe("#getSupportedTokens", () => {
         describe("token registry has tokens", () => {
             test("should return the list of token symbols and names", async () => {
+                // Get the result of the function we are testing.
                 const tokenSymbolList = await tokenApi.getSupportedTokens();
+
+                // Get a reference from an unsorted array of data we know is correct.
                 const expectedTokenSymbolList = TOKEN_REGISTRY_TRACKED_TOKENS.map((token) => {
                     return {
-                        address: token.address,
                         symbol: token.symbol,
                         name: token.name,
                         numDecimals: token.decimals,
                     };
                 });
 
-                expect(_.sortBy(tokenSymbolList, "symbol")).toEqual(
-                    _.sortBy(expectedTokenSymbolList, "symbol"),
-                );
+                // Sort both arrays for comparison.
+                const sortedResult = _.sortBy(tokenSymbolList, "symbol");
+                const sortedReference = _.sortBy(expectedTokenSymbolList, "symbol");
+
+                // For each set of token attributes, assert expectations.
+                sortedResult.forEach((tokenAttributes, index) => {
+                    const reference = sortedReference[index];
+
+                    expect(isNonNullAddress(tokenAttributes.address)).toEqual(true);
+                    expect(tokenAttributes.name).toEqual(reference.name);
+                    expect(tokenAttributes.symbol).toEqual(reference.symbol);
+                    expect(
+                        tokenAttributes.numDecimals.toNumber(),
+                    ).toEqual(reference.numDecimals);
+                });
             });
         });
     });

--- a/__test__/utils/utils.ts
+++ b/__test__/utils/utils.ts
@@ -1,0 +1,14 @@
+import { NULL_ADDRESS } from "../../utils/constants";
+
+/**
+ * Returns true if the given address string matches the format of an Ethereum address,
+ * and is not the null address (I.E. 0x0000000000000000000000000000000000000000).
+ *
+ * @param {string} address
+ * @returns {boolean}
+ */
+export const isNonNullAddress = (address: string) => {
+    const addressRegex = new RegExp("^0x[a-fA-F0-9]{40}$");
+
+    return address.match(addressRegex) && address !== NULL_ADDRESS;
+};

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -222,7 +222,9 @@ export class TokenAPI {
                     symbol,
                     name,
                     numDecimals,
-                ] = await tokenRegistry.getTokenAttributesByIndex.callAsync(new BigNumber(tokenIndex));
+                ] = await tokenRegistry.getTokenAttributesByIndex.callAsync(
+                    new BigNumber(tokenIndex),
+                );
 
                 return {
                     address,

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -221,7 +221,7 @@ export class TokenAPI {
                 const tokenSymbol = await tokenRegistry.tokenSymbolList.callAsync(
                     new BigNumber(tokenIndex),
                 );
-                
+
                 // Reference the local dictionary of token information, using the token symbol.
                 const tokenInfo = _.find(TOKEN_REGISTRY_TRACKED_TOKENS, { symbol: tokenSymbol });
 

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -232,4 +232,21 @@ export class TokenAPI {
             }),
         );
     }
+
+    /**
+     * Asynchronously retrieve the list of symbols of the tokens in the TokenRegistry.
+     *
+     * @returns {Promise<String[]>} the list of symbols of the tokens in the TokenRegistry.
+     */
+    public async getTokenSymbolList(): Promise<String[]> {
+        const tokenRegistry = await this.contracts.loadTokenRegistry();
+
+        const tokenSymbolListLength = await tokenRegistry.tokenSymbolListLength.callAsync();
+
+        const tokenSymbolList: Array<Promise<String>> = Array.from(
+            Array(tokenSymbolListLength.toNumber()).keys(),
+        ).map((i) => tokenRegistry.tokenSymbolList.callAsync(new BigNumber(i)));
+
+        return Promise.all(tokenSymbolList);
+    }
 }

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import * as singleLineString from "single-line-string";
 import * as Web3 from "web3";
 import { BigNumber } from "../../utils/bignumber";
@@ -6,7 +7,14 @@ import { Assertions } from "../invariants";
 import { TransactionOptions, TxData } from "../types";
 import { ContractsAPI } from "./";
 
+import { TOKEN_REGISTRY_TRACKED_TOKENS } from "../../utils/constants";
+
 const TRANSFER_GAS_MAXIMUM = 70000;
+
+export interface TokenAttributes {
+    symbol: string;
+    name: string;
+}
 
 export const TokenAPIErrors = {
     INSUFFICIENT_SENDER_BALANCE: (address) =>
@@ -198,19 +206,35 @@ export class TokenAPI {
     }
 
     /**
-     * Asynchronously retrieve the list of symbols of the tokens in the TokenRegistry.
+     * Returns an array of token attributes, including symbol and name, for tokens that are
+     * listed in Dharma's token registry.
      *
-     * @return              the list of symbols of the tokens in the TokenRegistry.
+     * @returns {Promise<TokenAttributes[]>}
      */
-    public async getTokenSymbolList(): Promise<String[]> {
+    public async getSupportedTokens(): Promise<TokenAttributes[]> {
         const tokenRegistry = await this.contracts.loadTokenRegistry();
 
         const tokenSymbolListLength = await tokenRegistry.tokenSymbolListLength.callAsync();
 
-        const tokenSymbolList: Array<Promise<String>> = Array.from(
-            Array(tokenSymbolListLength.toNumber()).keys(),
-        ).map((i) => tokenRegistry.tokenSymbolList.callAsync(new BigNumber(i)));
+        return Promise.all(
+            Array.from(
+                Array(tokenSymbolListLength.toNumber()).keys(),
+            ).map(async (tokenIndex) => {
+                const tokenSymbol = await tokenRegistry.tokenSymbolList.callAsync(
+                    new BigNumber(tokenIndex),
+                );
 
-        return Promise.all(tokenSymbolList);
+                // Reference the local dictionary of token information, using the token symbol.
+                const tokenInfo = _.find(
+                    TOKEN_REGISTRY_TRACKED_TOKENS,
+                    { symbol: tokenSymbol },
+                );
+
+                return {
+                    symbol: tokenSymbol,
+                    name: tokenInfo.name,
+                };
+            }),
+        );
     }
 }

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -217,18 +217,13 @@ export class TokenAPI {
         const tokenSymbolListLength = await tokenRegistry.tokenSymbolListLength.callAsync();
 
         return Promise.all(
-            Array.from(
-                Array(tokenSymbolListLength.toNumber()).keys(),
-            ).map(async (tokenIndex) => {
+            Array.from(Array(tokenSymbolListLength.toNumber()).keys()).map(async (tokenIndex) => {
                 const tokenSymbol = await tokenRegistry.tokenSymbolList.callAsync(
                     new BigNumber(tokenIndex),
                 );
-
+                __test__/integration/token_api.spec.ts
                 // Reference the local dictionary of token information, using the token symbol.
-                const tokenInfo = _.find(
-                    TOKEN_REGISTRY_TRACKED_TOKENS,
-                    { symbol: tokenSymbol },
-                );
+                const tokenInfo = _.find(TOKEN_REGISTRY_TRACKED_TOKENS, { symbol: tokenSymbol });
 
                 return {
                     symbol: tokenSymbol,

--- a/src/apis/token_api.ts
+++ b/src/apis/token_api.ts
@@ -221,7 +221,7 @@ export class TokenAPI {
                 const tokenSymbol = await tokenRegistry.tokenSymbolList.callAsync(
                     new BigNumber(tokenIndex),
                 );
-                __test__/integration/token_api.spec.ts
+                
                 // Reference the local dictionary of token information, using the token symbol.
                 const tokenInfo = _.find(TOKEN_REGISTRY_TRACKED_TOKENS, { symbol: tokenSymbol });
 


### PR DESCRIPTION
The basic diff is that we used to have a method to return a list of symbols in dharma.js, but this would return a list of symbols and names.

This could be used to populate the permissions section in plex, and the list of tokens when opening a loan request.