### PR TITLE
feat: add function assertFillableAsync

### DIFF
--- a/__test__/integration/order_api/order_api.spec.ts
+++ b/__test__/integration/order_api/order_api.spec.ts
@@ -101,6 +101,20 @@ describe("Order API (Integration Tests)", () => {
         });
     });
 
+    describe("#assertFillableAsync", () => {
+        describe("Valid, consensual orders", () => {
+            VALID_ORDERS.forEach(scenarioRunner.testAssertFillable);
+        });
+
+        describe("Invalid, consensual order fills", () => {
+            INVALID_ORDERS.forEach(scenarioRunner.testAssertFillable);
+        });
+
+        describe("Valid, non-consensual order fills", () => {
+            NONCONSENUAL_ORDERS.forEach(scenarioRunner.testAssertFillable);
+        });
+    });
+
     describe("#cancelOrderAsync", () => {
         describe("Invalid order cancellations", () => {
             INVALID_ORDER_CANCELLATIONS.forEach(scenarioRunner.testOrderCancelScenario);

--- a/__test__/integration/order_api/order_scenario_runner.ts
+++ b/__test__/integration/order_api/order_scenario_runner.ts
@@ -38,6 +38,7 @@ import { SimpleInterestLoanOrder } from "../../../src/adapters/simple_interest_l
 import * as Units from "../../../utils/units";
 import { Web3Utils } from "../../../utils/web3_utils";
 import { ACCOUNTS } from "../../accounts";
+import { isNonNullAddress } from "../../utils/utils";
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 
@@ -63,6 +64,7 @@ export class OrderScenarioRunner {
 
         this.testCheckOrderFilledScenario = this.testCheckOrderFilledScenario.bind(this);
         this.testFillScenario = this.testFillScenario.bind(this);
+        this.testAssertFillable = this.testAssertFillable.bind(this);
         this.testOrderCancelScenario = this.testOrderCancelScenario.bind(this);
         this.testIssuanceCancelScenario = this.testIssuanceCancelScenario.bind(this);
         this.testOrderGenerationScenario = this.testOrderGenerationScenario.bind(this);
@@ -142,6 +144,42 @@ export class OrderScenarioRunner {
                     expect(validateMock).toHaveBeenCalledWith(loanOrder);
                 });
             });
+        });
+    }
+
+    public testAssertFillable(scenario: FillScenario) {
+        describe(scenario.description, () => {
+            let debtOrder: DebtOrder.Instance;
+
+            beforeAll(() => {
+                ABIDecoder.addABI(this.debtKernel.abi);
+            });
+
+            afterAll(() => {
+                ABIDecoder.removeABI(this.debtKernel.abi);
+            });
+
+            beforeEach(async () => {
+                debtOrder = await this.setUpFillScenario(scenario);
+            });
+
+            if (scenario.successfullyFills) {
+                test("does not throw", async () => {
+                    await expect (
+                        this.orderApi.assertFillableAsync(debtOrder, {
+                            from: scenario.filler,
+                        }),
+                    ).resolves.not.toThrow();
+                });
+            } else {
+                test(`throws ${scenario.errorType} error`, async () => {
+                    await expect(
+                        this.orderApi.assertFillableAsync(
+                            debtOrder, { from: scenario.filler },
+                        ),
+                    ).rejects.toThrow(scenario.errorMessage);
+                });
+            }
         });
     }
 

--- a/__test__/integration/order_api/order_scenario_runner.ts
+++ b/__test__/integration/order_api/order_scenario_runner.ts
@@ -38,7 +38,6 @@ import { SimpleInterestLoanOrder } from "../../../src/adapters/simple_interest_l
 import * as Units from "../../../utils/units";
 import { Web3Utils } from "../../../utils/web3_utils";
 import { ACCOUNTS } from "../../accounts";
-import { isNonNullAddress } from "../../utils/utils";
 
 const TX_DEFAULTS = { from: ACCOUNTS[0].address, gas: 4712388 };
 
@@ -165,7 +164,7 @@ export class OrderScenarioRunner {
 
             if (scenario.successfullyFills) {
                 test("does not throw", async () => {
-                    await expect (
+                    await expect(
                         this.orderApi.assertFillableAsync(debtOrder, {
                             from: scenario.filler,
                         }),
@@ -174,9 +173,7 @@ export class OrderScenarioRunner {
             } else {
                 test(`throws ${scenario.errorType} error`, async () => {
                     await expect(
-                        this.orderApi.assertFillableAsync(
-                            debtOrder, { from: scenario.filler },
-                        ),
+                        this.orderApi.assertFillableAsync(debtOrder, { from: scenario.filler }),
                     ).rejects.toThrow(scenario.errorMessage);
                 });
             }

--- a/src/apis/order_api.ts
+++ b/src/apis/order_api.ts
@@ -151,7 +151,10 @@ export class OrderAPI {
      * @param {TxData} txOptions
      * @returns {Promise<void>}
      */
-    public async assertFillableAsync(debtOrder: DebtOrder.Instance, txOptions?: TxData): Promise<void> {
+    public async assertFillableAsync(
+        debtOrder: DebtOrder.Instance,
+        txOptions?: TxData,
+    ): Promise<void> {
         const {
             debtKernel,
             debtToken,
@@ -166,7 +169,7 @@ export class OrderAPI {
             txOptions,
         );
 
-        await this.assertValidLoanOrder(debtOrder);
+        await this.assertValidLoanTerms(debtOrder);
     }
 
     /**
@@ -330,17 +333,19 @@ export class OrderAPI {
     }
 
     /**
-     * Validates a given debtOrder against the appropriate loan order adapter.
+     * Validates a given debt order's terms against the appropriate loan order adapter.
      *
      * @param {DebtOrder.Instance} debtOrder
      * @returns {Promise<void>}
      */
-    private async assertValidLoanOrder(debtOrder: DebtOrder.Instance) {
+    private async assertValidLoanTerms(debtOrder: DebtOrder.Instance) {
         const adapter = await this.adapters.getAdapterByTermsContractAddress(
             debtOrder.termsContract,
         );
 
-        await adapter.validateAsync(await adapter.fromDebtOrder(debtOrder));
+        const loanOrder = await adapter.fromDebtOrder(debtOrder);
+
+        await adapter.validateAsync(loanOrder);
     }
 
     private async assertValidityInvariantsAsync(

--- a/src/apis/order_api.ts
+++ b/src/apis/order_api.ts
@@ -126,6 +126,32 @@ export class OrderAPI {
 
         debtOrder = await DebtOrder.applyNetworkDefaults(debtOrder, this.contracts);
 
+        await this.assertFillableAsync(debtOrder, options);
+
+        const { debtKernel } = await this.contracts.loadDharmaContractsAsync(txOptions);
+
+        const debtOrderWrapped = new DebtOrderWrapper(debtOrder);
+
+        return debtKernel.fillDebtOrder.sendTransactionAsync(
+            debtOrderWrapped.getCreditor(),
+            debtOrderWrapped.getOrderAddresses(),
+            debtOrderWrapped.getOrderValues(),
+            debtOrderWrapped.getOrderBytes32(),
+            debtOrderWrapped.getSignaturesV(),
+            debtOrderWrapped.getSignaturesR(),
+            debtOrderWrapped.getSignaturesS(),
+            txOptions,
+        );
+    }
+
+    /**
+     * Throws with error message if a given order is not able to be filled.
+     *
+     * @param {DebtOrder.Instance} debtOrder
+     * @param {TxData} txOptions
+     * @returns {Promise<void>}
+     */
+    public async assertFillableAsync(debtOrder: DebtOrder.Instance, txOptions?: TxData): Promise<void> {
         const {
             debtKernel,
             debtToken,
@@ -141,19 +167,6 @@ export class OrderAPI {
         );
 
         await this.assertValidLoanOrder(debtOrder);
-
-        const debtOrderWrapped = new DebtOrderWrapper(debtOrder);
-
-        return debtKernel.fillDebtOrder.sendTransactionAsync(
-            debtOrderWrapped.getCreditor(),
-            debtOrderWrapped.getOrderAddresses(),
-            debtOrderWrapped.getOrderValues(),
-            debtOrderWrapped.getOrderBytes32(),
-            debtOrderWrapped.getSignaturesV(),
-            debtOrderWrapped.getSignaturesR(),
-            debtOrderWrapped.getSignaturesS(),
-            txOptions,
-        );
     }
 
     /**


### PR DESCRIPTION
You can't see this so well in GitHub, for some reason, but the function being added is:

```typescript
    /**
     * Throws with error message if a given order is not able to be filled.
     *
     * @param {DebtOrder.Instance} debtOrder
     * @param {TxData} txOptions
     * @returns {Promise<void>}
     */
    public async assertFillableAsync(
        debtOrder: DebtOrder.Instance,
        txOptions?: TxData,
    ): Promise<void> {
        const {
            debtKernel,
            debtToken,
            tokenTransferProxy,
        } = await this.contracts.loadDharmaContractsAsync(txOptions);

        await this.assertValidityInvariantsAsync(debtOrder, debtKernel, debtToken);
        await this.assertConsensualityInvariants(debtOrder, txOptions);
        await this.assertCreditorBalanceAndAllowanceInvariantsAsync(
            debtOrder,
            tokenTransferProxy,
            txOptions,
        );

        await this.assertValidLoanOrder(debtOrder);
    }
```