### PR TITLE
Remove private keyword in favor of union type discrimination

### DIFF
--- a/src/types/token_amount.ts
+++ b/src/types/token_amount.ts
@@ -18,7 +18,7 @@ export interface RawTokenAmount extends BaseTokenAmountParams {
     rawAmount: BigNumber;
 }
 
-type TokenParams = DecimalTokenAmount | RawTokenAmount;
+export type TokenParams = DecimalTokenAmount | RawTokenAmount;
 
 export class TokenAmount {
     private static convertToRaw(decimalAmount: BigNumber, numDecimals: BigNumber): BigNumber {
@@ -32,7 +32,7 @@ export class TokenAmount {
     public readonly rawAmount: BigNumber;
     private token: Token;
 
-    private constructor(params: TokenParams) {
+    constructor(params: TokenParams) {
         switch (params.kind) {
             case "decimalTokenAmount":
                 this.token = new Token(params.symbol);


### PR DESCRIPTION
We use the union type discrimination pattern afforded by typescript to pass in a union type to the constructor and switch on the various ways in which the user can instantiate a `TokenAmount`.

We deprecated the static initializers in favor of this approach.

See documentation for union type discrimination here:

https://basarat.gitbooks.io/typescript/docs/types/discriminated-unions.html