### PR TITLE
refactor: add "async" suffix to transaction methods

### DIFF
--- a/__test__/integration/adapters/collateralized_simple_interest_loan_adapter/runners/return_collateral_runner.ts
+++ b/__test__/integration/adapters/collateralized_simple_interest_loan_adapter/runners/return_collateral_runner.ts
@@ -33,7 +33,7 @@ export class ReturnCollateralRunner extends BaseCollateralRunner {
                 }
 
                 if (scenario.collateralWithdrawn) {
-                    await this.adapter.returnCollateral(agreementId);
+                    await this.adapter.returnCollateralAsync(agreementId);
                 }
             });
 
@@ -44,7 +44,7 @@ export class ReturnCollateralRunner extends BaseCollateralRunner {
 
             if (scenario.succeeds) {
                 it("returns a valid transaction hash", async () => {
-                    const txHash = await this.adapter.returnCollateral(
+                    const txHash = await this.adapter.returnCollateralAsync(
                         scenario.givenAgreementId(agreementId),
                     );
 
@@ -61,7 +61,7 @@ export class ReturnCollateralRunner extends BaseCollateralRunner {
             } else {
                 it(`throws with message: ${scenario.error}`, async () => {
                     await expect(
-                        this.adapter.returnCollateral(scenario.givenAgreementId(agreementId)),
+                        this.adapter.returnCollateralAsync(scenario.givenAgreementId(agreementId)),
                     ).rejects.toThrow(scenario.error);
                 });
 

--- a/__test__/integration/adapters/collateralized_simple_interest_loan_adapter/runners/seize_collateral_runner.ts
+++ b/__test__/integration/adapters/collateralized_simple_interest_loan_adapter/runners/seize_collateral_runner.ts
@@ -33,7 +33,7 @@ export class SeizeCollateralRunner extends BaseCollateralRunner {
                 }
 
                 if (scenario.collateralWithdrawn) {
-                    await this.adapter.returnCollateral(agreementId);
+                    await this.adapter.returnCollateralAsync(agreementId);
                 }
             });
 
@@ -44,7 +44,7 @@ export class SeizeCollateralRunner extends BaseCollateralRunner {
 
             if (scenario.succeeds) {
                 it("returns a valid transaction hash", async () => {
-                    const txHash = await this.adapter.seizeCollateral(
+                    const txHash = await this.adapter.seizeCollateralAsync(
                         scenario.givenAgreementId(agreementId),
                     );
 
@@ -61,7 +61,7 @@ export class SeizeCollateralRunner extends BaseCollateralRunner {
             } else {
                 it(`throws with message: ${scenario.error}`, async () => {
                     await expect(
-                        this.adapter.seizeCollateral(scenario.givenAgreementId(agreementId)),
+                        this.adapter.seizeCollateralAsync(scenario.givenAgreementId(agreementId)),
                     ).rejects.toThrow(scenario.error);
                 });
 

--- a/__test__/integration/debt_token_api/runners/approve.ts
+++ b/__test__/integration/debt_token_api/runners/approve.ts
@@ -30,7 +30,7 @@ export class ApproveScenarioRunner extends ScenarioRunner {
                     Orders.MALFORMED_TOKEN_ID,
                 );
 
-                apiCallPromise = debtTokenAPI.approve(scenario.approvee, scenarioTokenID, {
+                apiCallPromise = debtTokenAPI.approveAsync(scenario.approvee, scenarioTokenID, {
                     from: scenario.approver,
                 });
             });

--- a/__test__/integration/debt_token_api/runners/get_approved.ts
+++ b/__test__/integration/debt_token_api/runners/get_approved.ts
@@ -27,11 +27,11 @@ export class GetApprovedScenarioRunner extends ScenarioRunner {
                 );
 
                 if (scenario.isApproved) {
-                    await debtTokenAPI.approve(scenario.approvee, orderOneTokenID, {
+                    await debtTokenAPI.approveAsync(scenario.approvee, orderOneTokenID, {
                         from: scenario.orderFilledByCreditorOne.creditor,
                     });
 
-                    await debtTokenAPI.approve(scenario.approvee, orderTwoTokenID, {
+                    await debtTokenAPI.approveAsync(scenario.approvee, orderTwoTokenID, {
                         from: scenario.orderFilledByCreditorTwo.creditor,
                     });
                 }

--- a/__test__/integration/debt_token_api/runners/is_approved_for_all.ts
+++ b/__test__/integration/debt_token_api/runners/is_approved_for_all.ts
@@ -10,7 +10,7 @@ export class IsApprovedForAllScenarioRunner extends ScenarioRunner {
         describe(scenario.description, () => {
             beforeEach(async () => {
                 if (scenario.isOperatorApproved) {
-                    await debtTokenAPI.setApprovalForAll(scenario.operator, true, {
+                    await debtTokenAPI.setApprovalForAllAsync(scenario.operator, true, {
                         from: scenario.owner,
                     });
                 }

--- a/__test__/integration/debt_token_api/runners/owner_of.ts
+++ b/__test__/integration/debt_token_api/runners/owner_of.ts
@@ -27,11 +27,11 @@ export class OwnerOfScenarioRunner extends ScenarioRunner {
                 );
 
                 if (scenario.transferee) {
-                    await debtTokenAPI.transfer(scenario.transferee, orderOneTokenID, {
+                    await debtTokenAPI.transferAsync(scenario.transferee, orderOneTokenID, {
                         from: scenario.orderFilledByCreditorOne.creditor,
                     });
 
-                    await debtTokenAPI.transfer(scenario.transferee, orderTwoTokenID, {
+                    await debtTokenAPI.transferAsync(scenario.transferee, orderTwoTokenID, {
                         from: scenario.orderFilledByCreditorTwo.creditor,
                     });
                 }

--- a/__test__/integration/debt_token_api/runners/set_approval_for_all.ts
+++ b/__test__/integration/debt_token_api/runners/set_approval_for_all.ts
@@ -15,9 +15,13 @@ export class SetApprovalForAllScenarioRunner extends ScenarioRunner {
                     });
                 }
 
-                apiCall = debtTokenAPI.setApprovalForAllAsync(scenario.operator, scenario.approved, {
-                    from: scenario.from,
-                });
+                apiCall = debtTokenAPI.setApprovalForAllAsync(
+                    scenario.operator,
+                    scenario.approved,
+                    {
+                        from: scenario.from,
+                    },
+                );
             });
 
             if (scenario.shouldSucceed) {

--- a/__test__/integration/debt_token_api/runners/set_approval_for_all.ts
+++ b/__test__/integration/debt_token_api/runners/set_approval_for_all.ts
@@ -10,12 +10,12 @@ export class SetApprovalForAllScenarioRunner extends ScenarioRunner {
         describe(scenario.description, () => {
             beforeEach(async () => {
                 if (scenario.alreadyApproved) {
-                    await debtTokenAPI.setApprovalForAll(scenario.operator, true, {
+                    await debtTokenAPI.setApprovalForAllAsync(scenario.operator, true, {
                         from: scenario.from,
                     });
                 }
 
-                apiCall = debtTokenAPI.setApprovalForAll(scenario.operator, scenario.approved, {
+                apiCall = debtTokenAPI.setApprovalForAllAsync(scenario.operator, scenario.approved, {
                     from: scenario.from,
                 });
             });

--- a/__test__/integration/debt_token_api/runners/transfer.ts
+++ b/__test__/integration/debt_token_api/runners/transfer.ts
@@ -5,6 +5,6 @@ export class TransferScenarioRunner extends TransferBaseScenarioRunner {
     protected getAPICallPromise(params: TransferAPICallParameters): Promise<string> {
         const { api, to, tokenID, txOptions } = params;
 
-        return api.transfer(to, tokenID, txOptions);
+        return api.transferAsync(to, tokenID, txOptions);
     }
 }

--- a/__test__/integration/debt_token_api/runners/transfer_base.ts
+++ b/__test__/integration/debt_token_api/runners/transfer_base.ts
@@ -80,7 +80,7 @@ export abstract class TransferBaseScenarioRunner extends ScenarioRunner {
                 });
 
                 // Set owner's approvals
-                await debtTokenAPI.setApprovalForAll(scenario.ownersApprovedOperator, true, {
+                await debtTokenAPI.setApprovalForAllAsync(scenario.ownersApprovedOperator, true, {
                     from: scenario.orderFilledByCreditorOne.creditor,
                 });
 

--- a/__test__/integration/debt_token_api/runners/transfer_base.ts
+++ b/__test__/integration/debt_token_api/runners/transfer_base.ts
@@ -75,7 +75,7 @@ export abstract class TransferBaseScenarioRunner extends ScenarioRunner {
                 );
 
                 // Set token approvals
-                await debtTokenAPI.approve(scenario.tokensApprovedOperator, orderOneTokenID, {
+                await debtTokenAPI.approveAsync(scenario.tokensApprovedOperator, orderOneTokenID, {
                     from: scenario.orderFilledByCreditorOne.creditor,
                 });
 

--- a/__test__/integration/debt_token_api/runners/transfer_from.ts
+++ b/__test__/integration/debt_token_api/runners/transfer_from.ts
@@ -5,6 +5,6 @@ export class TransferFromScenarioRunner extends TransferBaseScenarioRunner {
     protected getAPICallPromise(params: TransferAPICallParameters): Promise<string> {
         const { api, from, to, tokenID, data, txOptions } = params;
 
-        return api.transferFrom(from, to, tokenID, data, txOptions);
+        return api.transferFromAsync(from, to, tokenID, data, txOptions);
     }
 }

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -266,7 +266,7 @@ export class CollateralizedSimpleInterestLoanAdapter implements Adapter.Interfac
      * @param {string} agreementId
      * @returns {Promise<string>} The transaction's hash.
      */
-    public async seizeCollateral(agreementId: string): Promise<string> {
+    public async seizeCollateralAsync(agreementId: string): Promise<string> {
         this.assert.schema.bytes32("agreementId", agreementId);
 
         const transactionOptions = await this.getTxDefaultOptions();
@@ -289,7 +289,7 @@ export class CollateralizedSimpleInterestLoanAdapter implements Adapter.Interfac
      * @param {string} agreementId
      * @returns {Promise<string>} The transaction's hash.
      */
-    public async returnCollateral(agreementId: string): Promise<string> {
+    public async returnCollateralAsync(agreementId: string): Promise<string> {
         this.assert.schema.bytes32("agreementId", agreementId);
 
         await this.assertCollateralReturnable(agreementId);

--- a/src/apis/debt_token_api.ts
+++ b/src/apis/debt_token_api.ts
@@ -20,7 +20,7 @@ export interface ERC721 {
     ownerOf(tokenID: BigNumber): Promise<string>;
     exists(tokenID: BigNumber): Promise<boolean>;
 
-    approve(to: string, tokenID: BigNumber, options?: TxData): Promise<string>;
+    approveAsync(to: string, tokenID: BigNumber, options?: TxData): Promise<string>;
     getApproved(tokenID: BigNumber): Promise<string>;
 
     setApprovalForAll(operator: string, approved: boolean, options?: TxData): Promise<string>;
@@ -98,7 +98,7 @@ export class DebtTokenAPI implements ERC721 {
         return debtTokenContract.exists.callAsync(tokenID);
     }
 
-    public async approve(to: string, tokenID: BigNumber, options?: TxData): Promise<string> {
+    public async approveAsync(to: string, tokenID: BigNumber, options?: TxData): Promise<string> {
         // Assert `to` is a valid address.
         this.assert.schema.address("to", to);
 

--- a/src/apis/debt_token_api.ts
+++ b/src/apis/debt_token_api.ts
@@ -26,7 +26,7 @@ export interface ERC721 {
     setApprovalForAllAsync(operator: string, approved: boolean, options?: TxData): Promise<string>;
     isApprovedForAll(owner: string, operator: string): Promise<boolean>;
 
-    transfer(to: string, tokenID: BigNumber, options?: TxData): Promise<string>;
+    transferAsync(to: string, tokenID: BigNumber, options?: TxData): Promise<string>;
     transferFrom(
         from: string,
         to: string,
@@ -191,7 +191,7 @@ export class DebtTokenAPI implements ERC721 {
         return debtTokenContract.isApprovedForAll.callAsync(owner, operator);
     }
 
-    public async transfer(to: string, tokenID: BigNumber, options?: TxData): Promise<string> {
+    public async transferAsync(to: string, tokenID: BigNumber, options?: TxData): Promise<string> {
         this.validateTransferArguments(to, tokenID);
 
         const debtTokenContract = await this.contracts.loadDebtTokenAsync();

--- a/src/apis/debt_token_api.ts
+++ b/src/apis/debt_token_api.ts
@@ -23,7 +23,7 @@ export interface ERC721 {
     approveAsync(to: string, tokenID: BigNumber, options?: TxData): Promise<string>;
     getApproved(tokenID: BigNumber): Promise<string>;
 
-    setApprovalForAll(operator: string, approved: boolean, options?: TxData): Promise<string>;
+    setApprovalForAllAsync(operator: string, approved: boolean, options?: TxData): Promise<string>;
     isApprovedForAll(owner: string, operator: string): Promise<boolean>;
 
     transfer(to: string, tokenID: BigNumber, options?: TxData): Promise<string>;
@@ -157,7 +157,7 @@ export class DebtTokenAPI implements ERC721 {
         return debtTokenContract.getApproved.callAsync(tokenID);
     }
 
-    public async setApprovalForAll(
+    public async setApprovalForAllAsync(
         operator: string,
         approved: boolean,
         options?: TxData,

--- a/src/apis/debt_token_api.ts
+++ b/src/apis/debt_token_api.ts
@@ -27,7 +27,7 @@ export interface ERC721 {
     isApprovedForAll(owner: string, operator: string): Promise<boolean>;
 
     transferAsync(to: string, tokenID: BigNumber, options?: TxData): Promise<string>;
-    transferFrom(
+    transferFromAsync(
         from: string,
         to: string,
         tokenID: BigNumber,
@@ -214,7 +214,7 @@ export class DebtTokenAPI implements ERC721 {
         );
     }
 
-    public async transferFrom(
+    public async transferFromAsync(
         from: string,
         to: string,
         tokenID: BigNumber,

--- a/src/wrappers/contract_wrappers/collateralized_simple_interest_terms_contract_wrapper.ts
+++ b/src/wrappers/contract_wrappers/collateralized_simple_interest_terms_contract_wrapper.ts
@@ -102,7 +102,7 @@ export class CollateralizedSimpleInterestTermsContractContract extends BaseContr
                 self.returnCollateral.estimateGasAsync.bind(self, agreementId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.returnCollateralAsync,
+                self.web3ContractInstance.returnCollateral,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return txHash;
@@ -349,7 +349,7 @@ export class CollateralizedSimpleInterestTermsContractContract extends BaseContr
                 self.seizeCollateral.estimateGasAsync.bind(self, agreementId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.seizeCollateralAsync,
+                self.web3ContractInstance.seizeCollateral,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return txHash;

--- a/src/wrappers/contract_wrappers/collateralized_simple_interest_terms_contract_wrapper.ts
+++ b/src/wrappers/contract_wrappers/collateralized_simple_interest_terms_contract_wrapper.ts
@@ -102,7 +102,7 @@ export class CollateralizedSimpleInterestTermsContractContract extends BaseContr
                 self.returnCollateral.estimateGasAsync.bind(self, agreementId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.returnCollateral,
+                self.web3ContractInstance.returnCollateralAsync,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return txHash;
@@ -111,14 +111,14 @@ export class CollateralizedSimpleInterestTermsContractContract extends BaseContr
             const self = this as CollateralizedSimpleInterestTermsContractContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.returnCollateral.estimateGas,
+                self.web3ContractInstance.returnCollateralAsync.estimateGas,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return gas;
         },
         getABIEncodedTransactionData(agreementId: string, txData: TxData = {}): string {
             const self = this as CollateralizedSimpleInterestTermsContractContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.returnCollateral.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.returnCollateralAsync.getData();
             return abiEncodedTransactionData;
         },
     };
@@ -349,7 +349,7 @@ export class CollateralizedSimpleInterestTermsContractContract extends BaseContr
                 self.seizeCollateral.estimateGasAsync.bind(self, agreementId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.seizeCollateral,
+                self.web3ContractInstance.seizeCollateralAsync,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return txHash;
@@ -358,14 +358,14 @@ export class CollateralizedSimpleInterestTermsContractContract extends BaseContr
             const self = this as CollateralizedSimpleInterestTermsContractContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.seizeCollateral.estimateGas,
+                self.web3ContractInstance.seizeCollateralAsync.estimateGas,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return gas;
         },
         getABIEncodedTransactionData(agreementId: string, txData: TxData = {}): string {
             const self = this as CollateralizedSimpleInterestTermsContractContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.seizeCollateral.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.seizeCollateralAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/collateralizer_wrapper.ts
+++ b/src/wrappers/contract_wrappers/collateralizer_wrapper.ts
@@ -80,7 +80,7 @@ export class CollateralizerContract extends BaseContract {
                 self.returnCollateral.estimateGasAsync.bind(self, agreementId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.returnCollateral,
+                self.web3ContractInstance.returnCollateralAsync,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return txHash;
@@ -89,14 +89,14 @@ export class CollateralizerContract extends BaseContract {
             const self = this as CollateralizerContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.returnCollateral.estimateGas,
+                self.web3ContractInstance.returnCollateralAsync.estimateGas,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return gas;
         },
         getABIEncodedTransactionData(agreementId: string, txData: TxData = {}): string {
             const self = this as CollateralizerContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.returnCollateral.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.returnCollateralAsync.getData();
             return abiEncodedTransactionData;
         },
     };
@@ -308,7 +308,7 @@ export class CollateralizerContract extends BaseContract {
                 self.seizeCollateral.estimateGasAsync.bind(self, agreementId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.seizeCollateral,
+                self.web3ContractInstance.seizeCollateralAsync,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return txHash;
@@ -317,14 +317,14 @@ export class CollateralizerContract extends BaseContract {
             const self = this as CollateralizerContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.seizeCollateral.estimateGas,
+                self.web3ContractInstance.seizeCollateralAsync.estimateGas,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return gas;
         },
         getABIEncodedTransactionData(agreementId: string, txData: TxData = {}): string {
             const self = this as CollateralizerContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.seizeCollateral.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.seizeCollateralAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/collateralizer_wrapper.ts
+++ b/src/wrappers/contract_wrappers/collateralizer_wrapper.ts
@@ -80,7 +80,7 @@ export class CollateralizerContract extends BaseContract {
                 self.returnCollateral.estimateGasAsync.bind(self, agreementId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.returnCollateralAsync,
+                self.web3ContractInstance.returnCollateral,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return txHash;
@@ -308,7 +308,7 @@ export class CollateralizerContract extends BaseContract {
                 self.seizeCollateral.estimateGasAsync.bind(self, agreementId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.seizeCollateralAsync,
+                self.web3ContractInstance.seizeCollateral,
                 self.web3ContractInstance,
             )(agreementId, txDataWithDefaults);
             return txHash;

--- a/src/wrappers/contract_wrappers/debt_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_token_wrapper.ts
@@ -67,7 +67,7 @@ export class DebtTokenContract extends BaseContract {
                 self.approve.estimateGasAsync.bind(self, _to, _tokenId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.approveAsync,
+                self.web3ContractInstance.approve,
                 self.web3ContractInstance,
             )(_to, _tokenId, txDataWithDefaults);
             return txHash;
@@ -80,7 +80,7 @@ export class DebtTokenContract extends BaseContract {
             const self = this as DebtTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.approveAsync.estimateGas,
+                self.web3ContractInstance.approve.estimateGas,
                 self.web3ContractInstance,
             )(_to, _tokenId, txDataWithDefaults);
             return gas;
@@ -91,7 +91,7 @@ export class DebtTokenContract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as DebtTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.approveAsync.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.approve.getData();
             return abiEncodedTransactionData;
         },
     };
@@ -118,7 +118,7 @@ export class DebtTokenContract extends BaseContract {
                 self.transferFrom.estimateGasAsync.bind(self, _from, _to, _tokenId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferFromAsync,
+                self.web3ContractInstance.transferFrom,
                 self.web3ContractInstance,
             )(_from, _to, _tokenId, txDataWithDefaults);
             return txHash;
@@ -454,7 +454,7 @@ export class DebtTokenContract extends BaseContract {
                 self.setApprovalForAll.estimateGasAsync.bind(self, _to, _approved),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.setApprovalForAllAsync,
+                self.web3ContractInstance.setApprovalForAll,
                 self.web3ContractInstance,
             )(_to, _approved, txDataWithDefaults);
             return txHash;
@@ -490,7 +490,7 @@ export class DebtTokenContract extends BaseContract {
                 self.transfer.estimateGasAsync.bind(self, _to, _tokenId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferAsync,
+                self.web3ContractInstance.transfer,
                 self.web3ContractInstance,
             )(_to, _tokenId, txDataWithDefaults);
             return txHash;

--- a/src/wrappers/contract_wrappers/debt_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_token_wrapper.ts
@@ -67,7 +67,7 @@ export class DebtTokenContract extends BaseContract {
                 self.approve.estimateGasAsync.bind(self, _to, _tokenId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.approve,
+                self.web3ContractInstance.approveAsync,
                 self.web3ContractInstance,
             )(_to, _tokenId, txDataWithDefaults);
             return txHash;
@@ -80,7 +80,7 @@ export class DebtTokenContract extends BaseContract {
             const self = this as DebtTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.approve.estimateGas,
+                self.web3ContractInstance.approveAsync.estimateGas,
                 self.web3ContractInstance,
             )(_to, _tokenId, txDataWithDefaults);
             return gas;
@@ -91,7 +91,7 @@ export class DebtTokenContract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as DebtTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.approve.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.approveAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/debt_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_token_wrapper.ts
@@ -490,7 +490,7 @@ export class DebtTokenContract extends BaseContract {
                 self.transfer.estimateGasAsync.bind(self, _to, _tokenId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transfer,
+                self.web3ContractInstance.transferAsync,
                 self.web3ContractInstance,
             )(_to, _tokenId, txDataWithDefaults);
             return txHash;
@@ -503,7 +503,7 @@ export class DebtTokenContract extends BaseContract {
             const self = this as DebtTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.transfer.estimateGas,
+                self.web3ContractInstance.transferAsync.estimateGas,
                 self.web3ContractInstance,
             )(_to, _tokenId, txDataWithDefaults);
             return gas;
@@ -514,7 +514,7 @@ export class DebtTokenContract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as DebtTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.transfer.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.transferAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/debt_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_token_wrapper.ts
@@ -118,7 +118,7 @@ export class DebtTokenContract extends BaseContract {
                 self.transferFrom.estimateGasAsync.bind(self, _from, _to, _tokenId),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferFrom,
+                self.web3ContractInstance.transferFromAsync,
                 self.web3ContractInstance,
             )(_from, _to, _tokenId, txDataWithDefaults);
             return txHash;
@@ -132,7 +132,7 @@ export class DebtTokenContract extends BaseContract {
             const self = this as DebtTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.transferFrom.estimateGas,
+                self.web3ContractInstance.transferFromAsync.estimateGas,
                 self.web3ContractInstance,
             )(_from, _to, _tokenId, txDataWithDefaults);
             return gas;
@@ -144,7 +144,7 @@ export class DebtTokenContract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as DebtTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.transferFrom.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.transferFromAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/debt_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/debt_token_wrapper.ts
@@ -454,7 +454,7 @@ export class DebtTokenContract extends BaseContract {
                 self.setApprovalForAll.estimateGasAsync.bind(self, _to, _approved),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.setApprovalForAll,
+                self.web3ContractInstance.setApprovalForAllAsync,
                 self.web3ContractInstance,
             )(_to, _approved, txDataWithDefaults);
             return txHash;
@@ -467,14 +467,14 @@ export class DebtTokenContract extends BaseContract {
             const self = this as DebtTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.setApprovalForAll.estimateGas,
+                self.web3ContractInstance.setApprovalForAllAsync.estimateGas,
                 self.web3ContractInstance,
             )(_to, _approved, txDataWithDefaults);
             return gas;
         },
         getABIEncodedTransactionData(_to: string, _approved: boolean, txData: TxData = {}): string {
             const self = this as DebtTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.setApprovalForAll.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.setApprovalForAllAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/dummy_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/dummy_token_wrapper.ts
@@ -46,7 +46,7 @@ export class DummyTokenContract extends BaseContract {
                 self.approve.estimateGasAsync.bind(self, _spender, _value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.approve,
+                self.web3ContractInstance.approveAsync,
                 self.web3ContractInstance,
             )(_spender, _value, txDataWithDefaults);
             return txHash;
@@ -59,7 +59,7 @@ export class DummyTokenContract extends BaseContract {
             const self = this as DummyTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.approve.estimateGas,
+                self.web3ContractInstance.approveAsync.estimateGas,
                 self.web3ContractInstance,
             )(_spender, _value, txDataWithDefaults);
             return gas;
@@ -70,7 +70,7 @@ export class DummyTokenContract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as DummyTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.approve.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.approveAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/dummy_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/dummy_token_wrapper.ts
@@ -97,7 +97,7 @@ export class DummyTokenContract extends BaseContract {
                 self.transferFrom.estimateGasAsync.bind(self, _from, _to, _value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferFrom,
+                self.web3ContractInstance.transferFromAsync,
                 self.web3ContractInstance,
             )(_from, _to, _value, txDataWithDefaults);
             return txHash;
@@ -111,7 +111,7 @@ export class DummyTokenContract extends BaseContract {
             const self = this as DummyTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.transferFrom.estimateGas,
+                self.web3ContractInstance.transferFromAsync.estimateGas,
                 self.web3ContractInstance,
             )(_from, _to, _value, txDataWithDefaults);
             return gas;
@@ -123,7 +123,7 @@ export class DummyTokenContract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as DummyTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.transferFrom.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.transferFromAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/dummy_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/dummy_token_wrapper.ts
@@ -46,7 +46,7 @@ export class DummyTokenContract extends BaseContract {
                 self.approve.estimateGasAsync.bind(self, _spender, _value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.approveAsync,
+                self.web3ContractInstance.approve,
                 self.web3ContractInstance,
             )(_spender, _value, txDataWithDefaults);
             return txHash;
@@ -59,7 +59,7 @@ export class DummyTokenContract extends BaseContract {
             const self = this as DummyTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.approveAsync.estimateGas,
+                self.web3ContractInstance.approve.estimateGas,
                 self.web3ContractInstance,
             )(_spender, _value, txDataWithDefaults);
             return gas;
@@ -70,7 +70,7 @@ export class DummyTokenContract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as DummyTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.approveAsync.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.approve.getData();
             return abiEncodedTransactionData;
         },
     };
@@ -97,7 +97,7 @@ export class DummyTokenContract extends BaseContract {
                 self.transferFrom.estimateGasAsync.bind(self, _from, _to, _value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferFromAsync,
+                self.web3ContractInstance.transferFrom,
                 self.web3ContractInstance,
             )(_from, _to, _value, txDataWithDefaults);
             return txHash;
@@ -283,7 +283,7 @@ export class DummyTokenContract extends BaseContract {
                 self.transfer.estimateGasAsync.bind(self, _to, _value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferAsync,
+                self.web3ContractInstance.transfer,
                 self.web3ContractInstance,
             )(_to, _value, txDataWithDefaults);
             return txHash;

--- a/src/wrappers/contract_wrappers/dummy_token_wrapper.ts
+++ b/src/wrappers/contract_wrappers/dummy_token_wrapper.ts
@@ -283,7 +283,7 @@ export class DummyTokenContract extends BaseContract {
                 self.transfer.estimateGasAsync.bind(self, _to, _value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transfer,
+                self.web3ContractInstance.transferAsync,
                 self.web3ContractInstance,
             )(_to, _value, txDataWithDefaults);
             return txHash;
@@ -296,14 +296,14 @@ export class DummyTokenContract extends BaseContract {
             const self = this as DummyTokenContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.transfer.estimateGas,
+                self.web3ContractInstance.transferAsync.estimateGas,
                 self.web3ContractInstance,
             )(_to, _value, txDataWithDefaults);
             return gas;
         },
         getABIEncodedTransactionData(_to: string, _value: BigNumber, txData: TxData = {}): string {
             const self = this as DummyTokenContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.transfer.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.transferAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/erc20_wrapper.ts
+++ b/src/wrappers/contract_wrappers/erc20_wrapper.ts
@@ -77,7 +77,7 @@ export class ERC20Contract extends BaseContract {
                 self.transferFrom.estimateGasAsync.bind(self, from, to, value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferFrom,
+                self.web3ContractInstance.transferFromAsync,
                 self.web3ContractInstance,
             )(from, to, value, txDataWithDefaults);
             return txHash;
@@ -91,7 +91,7 @@ export class ERC20Contract extends BaseContract {
             const self = this as ERC20Contract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.transferFrom.estimateGas,
+                self.web3ContractInstance.transferFromAsync.estimateGas,
                 self.web3ContractInstance,
             )(from, to, value, txDataWithDefaults);
             return gas;
@@ -103,7 +103,7 @@ export class ERC20Contract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as ERC20Contract;
-            const abiEncodedTransactionData = self.web3ContractInstance.transferFrom.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.transferFromAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/erc20_wrapper.ts
+++ b/src/wrappers/contract_wrappers/erc20_wrapper.ts
@@ -129,7 +129,7 @@ export class ERC20Contract extends BaseContract {
                 self.transfer.estimateGasAsync.bind(self, to, value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transfer,
+                self.web3ContractInstance.transferAsync,
                 self.web3ContractInstance,
             )(to, value, txDataWithDefaults);
             return txHash;
@@ -138,14 +138,14 @@ export class ERC20Contract extends BaseContract {
             const self = this as ERC20Contract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.transfer.estimateGas,
+                self.web3ContractInstance.transferAsync.estimateGas,
                 self.web3ContractInstance,
             )(to, value, txDataWithDefaults);
             return gas;
         },
         getABIEncodedTransactionData(to: string, value: BigNumber, txData: TxData = {}): string {
             const self = this as ERC20Contract;
-            const abiEncodedTransactionData = self.web3ContractInstance.transfer.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.transferAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/erc20_wrapper.ts
+++ b/src/wrappers/contract_wrappers/erc20_wrapper.ts
@@ -26,7 +26,7 @@ export class ERC20Contract extends BaseContract {
                 self.approve.estimateGasAsync.bind(self, spender, value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.approveAsync,
+                self.web3ContractInstance.approve,
                 self.web3ContractInstance,
             )(spender, value, txDataWithDefaults);
             return txHash;
@@ -39,7 +39,7 @@ export class ERC20Contract extends BaseContract {
             const self = this as ERC20Contract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.approveAsync.estimateGas,
+                self.web3ContractInstance.approve.estimateGas,
                 self.web3ContractInstance,
             )(spender, value, txDataWithDefaults);
             return gas;
@@ -50,7 +50,7 @@ export class ERC20Contract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as ERC20Contract;
-            const abiEncodedTransactionData = self.web3ContractInstance.approveAsync.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.approve.getData();
             return abiEncodedTransactionData;
         },
     };
@@ -77,7 +77,7 @@ export class ERC20Contract extends BaseContract {
                 self.transferFrom.estimateGasAsync.bind(self, from, to, value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferFromAsync,
+                self.web3ContractInstance.transferFrom,
                 self.web3ContractInstance,
             )(from, to, value, txDataWithDefaults);
             return txHash;
@@ -129,7 +129,7 @@ export class ERC20Contract extends BaseContract {
                 self.transfer.estimateGasAsync.bind(self, to, value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferAsync,
+                self.web3ContractInstance.transfer,
                 self.web3ContractInstance,
             )(to, value, txDataWithDefaults);
             return txHash;

--- a/src/wrappers/contract_wrappers/erc20_wrapper.ts
+++ b/src/wrappers/contract_wrappers/erc20_wrapper.ts
@@ -26,7 +26,7 @@ export class ERC20Contract extends BaseContract {
                 self.approve.estimateGasAsync.bind(self, spender, value),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.approve,
+                self.web3ContractInstance.approveAsync,
                 self.web3ContractInstance,
             )(spender, value, txDataWithDefaults);
             return txHash;
@@ -39,7 +39,7 @@ export class ERC20Contract extends BaseContract {
             const self = this as ERC20Contract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.approve.estimateGas,
+                self.web3ContractInstance.approveAsync.estimateGas,
                 self.web3ContractInstance,
             )(spender, value, txDataWithDefaults);
             return gas;
@@ -50,7 +50,7 @@ export class ERC20Contract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as ERC20Contract;
-            const abiEncodedTransactionData = self.web3ContractInstance.approve.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.approveAsync.getData();
             return abiEncodedTransactionData;
         },
     };

--- a/src/wrappers/contract_wrappers/token_transfer_proxy_wrapper.ts
+++ b/src/wrappers/contract_wrappers/token_transfer_proxy_wrapper.ts
@@ -56,7 +56,7 @@ export class TokenTransferProxyContract extends BaseContract {
                 self.transferFrom.estimateGasAsync.bind(self, _token, _from, _to, _amount),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferFromAsync,
+                self.web3ContractInstance.transferFrom,
                 self.web3ContractInstance,
             )(_token, _from, _to, _amount, txDataWithDefaults);
             return txHash;

--- a/src/wrappers/contract_wrappers/token_transfer_proxy_wrapper.ts
+++ b/src/wrappers/contract_wrappers/token_transfer_proxy_wrapper.ts
@@ -56,7 +56,7 @@ export class TokenTransferProxyContract extends BaseContract {
                 self.transferFrom.estimateGasAsync.bind(self, _token, _from, _to, _amount),
             );
             const txHash = await promisify<string>(
-                self.web3ContractInstance.transferFrom,
+                self.web3ContractInstance.transferFromAsync,
                 self.web3ContractInstance,
             )(_token, _from, _to, _amount, txDataWithDefaults);
             return txHash;
@@ -71,7 +71,7 @@ export class TokenTransferProxyContract extends BaseContract {
             const self = this as TokenTransferProxyContract;
             const txDataWithDefaults = await self.applyDefaultsToTxDataAsync(txData);
             const gas = await promisify<number>(
-                self.web3ContractInstance.transferFrom.estimateGas,
+                self.web3ContractInstance.transferFromAsync.estimateGas,
                 self.web3ContractInstance,
             )(_token, _from, _to, _amount, txDataWithDefaults);
             return gas;
@@ -84,7 +84,7 @@ export class TokenTransferProxyContract extends BaseContract {
             txData: TxData = {},
         ): string {
             const self = this as TokenTransferProxyContract;
-            const abiEncodedTransactionData = self.web3ContractInstance.transferFrom.getData();
+            const abiEncodedTransactionData = self.web3ContractInstance.transferFromAsync.getData();
             return abiEncodedTransactionData;
         },
     };


### PR DESCRIPTION
Renames the following functions:

approve => approveAsync
setApprovalForAll => setApprovalForAllAsync
transfer => transferAsync
transferFrom => transferFromAsync
seizeCollateral => seizeCollateralAsync
setApprovalForAll => setApprovalForAllAsync
returnCollateral => returnCollateralAsync

Note: This will break some Dharma.js consumers. Better sooner than later, perhaps.