### PR TITLE
build: fix umd default export

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,5 @@
 tslint:
   enabled: true
   config_file: tslint.json
+jshint:
+  enabled: false

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,26 +1,27 @@
 /**
  * This is to generate the umd bundle only
  */
-const webpack = require('webpack');
-const path = require('path');
+const webpack = require("webpack");
+const path = require("path");
 
 let entry = {
-    index: './src/index.ts',
+    index: "./src/index.ts",
 };
 
 module.exports = {
     entry,
     output: {
-        path: path.resolve(__dirname, 'dist'),
-        filename: 'dharma.umd.js',
-        libraryTarget: 'umd',
-        library: 'Dharma',
+        path: path.resolve(__dirname, "dist"),
+        filename: "dharma.umd.js",
+        libraryTarget: "umd",
+        libraryExport: "default",
+        library: "Dharma",
         umdNamedDefine: true,
     },
     resolve: {
-        extensions: ['.ts', '.js']
+        extensions: [".ts", ".js"],
     },
-    devtool: 'source-map',
+    devtool: "source-map",
     plugins: [
         new webpack.optimize.UglifyJsPlugin({
             minimize: true,
@@ -34,17 +35,13 @@ module.exports = {
                 test: /\.ts$/,
                 use: [
                     {
-                        loader: 'awesome-typescript-loader',
+                        loader: "awesome-typescript-loader",
                         options: {
-                            configFileName: "tsconfig.prod.json"
+                            configFileName: "tsconfig.prod.json",
                         },
                     },
                 ],
-                exclude: [
-                    /node_modules/,
-                    /__test__/,
-                    /__mocks__/
-                ]
+                exclude: [/node_modules/, /__test__/, /__mocks__/],
             },
         ],
     },


### PR DESCRIPTION
This PR introduces the following changes:

- A bug had been reported in which importing `dharma.js` in non-ES6 syntax (i.e. `const Dharma = require("@dharmaprotocol/dharma.js")`) lead to users having to use really wonky instantiation syntax (i.e `const dharma = new Dharma(...)` wouldn't work but `const dharma = new Dharma.default(...)` would). This fixes our webpack configuration to address this issue.  See [here](https://github.com/webpack/webpack/issues/3929) for more details