### PR TITLE
build: bumped contracts to 0.0.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "webpack": "^3.11.0"
     },
     "dependencies": {
-        "@dharmaprotocol/contracts": "0.0.40",
+        "@dharmaprotocol/contracts": "0.0.41",
         "@types/lodash": "^4.14.104",
         "abi-decoder": "https://github.com/dharmaprotocol/abi-decoder",
         "bignumber.js": "^5.0.0",

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -282,6 +282,7 @@ export class CollateralizedSimpleInterestLoanAdapter implements Adapter {
 
         const transactionOptions = _.assign(defaultOptions, options);
 
+        await this.assertDebtAgreementExists(agreementId);
         await this.assertCollateralSeizeable(agreementId);
 
         const collateralizerContract = await this.contractsAPI.loadCollateralizerAsync();
@@ -304,6 +305,7 @@ export class CollateralizedSimpleInterestLoanAdapter implements Adapter {
     public async returnCollateralAsync(agreementId: string, options?: TxData): Promise<string> {
         this.assert.schema.bytes32("agreementId", agreementId);
 
+        await this.assertDebtAgreementExists(agreementId);
         await this.assertCollateralReturnable(agreementId);
 
         const defaultOptions = await this.getTxDefaultOptions();
@@ -424,6 +426,16 @@ export class CollateralizedSimpleInterestLoanAdapter implements Adapter {
                 CollateralizerAdapterErrors.MISMATCHED_TERMS_CONTRACT(termsContractAddress),
             );
         }
+    }
+
+    private async assertDebtAgreementExists(agreementId: string): Promise<void> {
+        const debtTokenContract = await this.contractsAPI.loadDebtTokenAsync();
+
+        return this.assert.debtAgreement.exists(
+            agreementId,
+            debtTokenContract,
+            CollateralizerAdapterErrors.COLLATERAL_NOT_FOUND(agreementId),
+        );
     }
 
     /**

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -36,6 +36,12 @@ export const TERMS_CONTRACT_TYPES = {
 
 export const TOKEN_REGISTRY_TRACKED_TOKENS = [
     {
+        address: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+        name: "Dai Stablecoin",
+        symbol: "DAI",
+        decimals: 18,
+    },
+    {
         address: "0xe94327d07fc17907b4db788e5adf2ed424addff6",
         name: "Augur REP",
         symbol: "REP",

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,9 +132,9 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dharmaprotocol/contracts@0.0.40":
-  version "0.0.40"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.40.tgz#45bd72070114b745563d9d33900782bbd5546de4"
+"@dharmaprotocol/contracts@0.0.41":
+  version "0.0.41"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.41.tgz#7fd847850b257c0f00b695700f8214467d3f8108"
   dependencies:
     zeppelin-solidity "1.8.0"
 


### PR DESCRIPTION
This PR introduces the following changes:

- Bumps contracts to 0.0.41 to deploy new contracts to Kovan
