### PR TITLE
build: bump dharma contracts onto mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "webpack": "^3.11.0"
     },
     "dependencies": {
-        "@dharmaprotocol/contracts": "0.0.41",
+        "@dharmaprotocol/contracts": "0.1.0",
         "@types/lodash": "^4.14.104",
         "abi-decoder": "https://github.com/dharmaprotocol/abi-decoder",
         "bignumber.js": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,9 +132,9 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dharmaprotocol/contracts@0.0.41":
-  version "0.0.41"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.41.tgz#7fd847850b257c0f00b695700f8214467d3f8108"
+"@dharmaprotocol/contracts@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.1.0.tgz#10ba8a3b09b65699d84501e093e2149beb863c00"
   dependencies:
     zeppelin-solidity "1.8.0"
 


### PR DESCRIPTION
This PR introduces the following changes:

- Bumps @dharmaprotocol/contracts to 0.1.0