### PR TITLE
Enforce all Collateralizer invariants

### DIFF
--- a/__test__/integration/order_api/scenarios/invalid_orders.ts
+++ b/__test__/integration/order_api/scenarios/invalid_orders.ts
@@ -1,19 +1,19 @@
-import {
-    DebtKernelContract,
-    RepaymentRouterContract,
-    DummyTokenContract,
-    SimpleInterestTermsContractContract,
-    CollateralizedSimpleInterestTermsContractContract,
-} from "src/wrappers";
-import * as Units from "utils/units";
-import * as moment from "moment";
-import { DebtOrder } from "src/types";
-import { DebtOrderWrapper } from "src/wrappers";
-import { BigNumber } from "utils/bignumber";
 import { ACCOUNTS } from "__test__/accounts";
-import { NULL_ADDRESS, NULL_BYTES32 } from "utils/constants";
-import { OrderAPIErrors } from "src/apis/order_api";
+import * as moment from "moment";
 import { CollateralizerAdapterErrors } from "src/adapters/collateralized_simple_interest_loan_adapter";
+import { OrderAPIErrors } from "src/apis/order_api";
+import { DebtOrder } from "src/types";
+import {
+    CollateralizedSimpleInterestTermsContractContract,
+    DebtKernelContract,
+    DebtOrderWrapper,
+    DummyTokenContract,
+    RepaymentRouterContract,
+    SimpleInterestTermsContractContract,
+} from "src/wrappers";
+import { BigNumber } from "utils/bignumber";
+import { NULL_ADDRESS, NULL_BYTES32 } from "utils/constants";
+import * as Units from "utils/units";
 
 import { FillScenario } from "./";
 

--- a/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
@@ -16,6 +16,7 @@ import * as Web3 from "web3";
 import { BigNumber } from "../../../utils/bignumber";
 import * as Units from "../../../utils/units";
 import { Web3Utils } from "../../../utils/web3_utils";
+import { TOKEN_REGISTRY_TRACKED_TOKENS } from "../../../utils/constants";
 import { ACCOUNTS } from "../../accounts";
 
 // wrappers
@@ -119,6 +120,22 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                 );
             });
         });
+        describe("...with collateral token index that is not tracked", () => {
+            test("should throw INVALID_TOKEN_INDEX error", () => {
+                const invalidCollateralTokenIndex = new BigNumber(
+                    TOKEN_REGISTRY_TRACKED_TOKENS.length,
+                );
+
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario1.unpackedParams,
+                        collateralTokenIndex: invalidCollateralTokenIndex,
+                    });
+                }).toThrow(
+                    CollateralizerAdapterErrors.INVALID_TOKEN_INDEX(invalidCollateralTokenIndex),
+                );
+            });
+        });
         describe("...with collateral amount > 2^92 - 1", () => {
             test("should throw COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM error", () => {
                 expect(() => {
@@ -134,9 +151,19 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
                 expect(() => {
                     collateralizedLoanTerms.packParameters({
                         ...scenario1.unpackedParams,
+                        collateralAmount: new BigNumber(0),
+                    });
+                }).toThrow(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_MUST_BE_POSITIVE());
+            });
+        });
+        describe("...with collateral amount = 0", () => {
+            test("should throw COLLATERAL_AMOUNT_IS_NEGATIVE error", () => {
+                expect(() => {
+                    collateralizedLoanTerms.packParameters({
+                        ...scenario1.unpackedParams,
                         collateralAmount: new BigNumber(-1),
                     });
-                }).toThrow(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
+                }).toThrow(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_MUST_BE_POSITIVE());
             });
         });
         describe("...with collateral amount containing decimals", () => {

--- a/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
+++ b/__test__/unit/adapters/collateralized_simple_interest_loan_adapter.spec.ts
@@ -14,9 +14,9 @@ import * as Web3 from "web3";
 
 // utils
 import { BigNumber } from "../../../utils/bignumber";
+import { TOKEN_REGISTRY_TRACKED_TOKENS } from "../../../utils/constants";
 import * as Units from "../../../utils/units";
 import { Web3Utils } from "../../../utils/web3_utils";
-import { TOKEN_REGISTRY_TRACKED_TOKENS } from "../../../utils/constants";
 import { ACCOUNTS } from "../../accounts";
 
 // wrappers
@@ -147,7 +147,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
             });
         });
         describe("...with collateral amount < 0", () => {
-            test("should throw COLLATERAL_AMOUNT_IS_NEGATIVE error", () => {
+            test("should throw COLLATERAL_AMOUNT_MUST_BE_POSITIVE error", () => {
                 expect(() => {
                     collateralizedLoanTerms.packParameters({
                         ...scenario1.unpackedParams,
@@ -157,7 +157,7 @@ describe("Collateralized Terms Contract Interface (Unit Tests)", () => {
             });
         });
         describe("...with collateral amount = 0", () => {
-            test("should throw COLLATERAL_AMOUNT_IS_NEGATIVE error", () => {
+            test("should throw COLLATERAL_AMOUNT_MUST_BE_POSITIVE error", () => {
                 expect(() => {
                     collateralizedLoanTerms.packParameters({
                         ...scenario1.unpackedParams,

--- a/src/adapters/collateralized_simple_interest_loan_adapter.ts
+++ b/src/adapters/collateralized_simple_interest_loan_adapter.ts
@@ -55,7 +55,8 @@ export const CollateralizerAdapterErrors = {
         singleLineString`Token Registry does not track a token at index
                          ${tokenIndex.toString()}.`,
 
-    COLLATERAL_AMOUNT_IS_NEGATIVE: () => singleLineString`Collateral amount cannot be negative.`,
+    COLLATERAL_AMOUNT_MUST_BE_POSITIVE: () =>
+        singleLineString`Collateral amount must be greater than zero.`,
 
     COLLATERAL_AMOUNT_EXCEEDS_MAXIMUM: () =>
         singleLineString`Collateral amount exceeds maximum value of 2^92 - 1.`,

--- a/src/adapters/collateralized_simple_interest_loan_terms.ts
+++ b/src/adapters/collateralized_simple_interest_loan_terms.ts
@@ -1,18 +1,22 @@
+// External
 import * as Web3 from "web3";
-
 import { BigNumber } from "../../utils/bignumber";
 
+// APIs
 import { ContractsAPI } from "../apis";
-import { Assertions } from "../invariants";
 
+// Utils
+import { Assertions } from "../invariants";
 import { TermsContractParameters } from "./terms_contract_parameters";
 
+// Constants
+import { TOKEN_REGISTRY_TRACKED_TOKENS } from "../../utils/constants";
 import {
     CollateralizedTermsContractParameters,
     CollateralizerAdapterErrors,
 } from "./collateralized_simple_interest_loan_adapter";
 
-const MAX_COLLATERAL_TOKEN_INDEX_HEX = TermsContractParameters.generateHexValueOfLength(2);
+const MAX_COLLATERAL_TOKEN_INDEX_HEX = (TOKEN_REGISTRY_TRACKED_TOKENS.length - 1).toString(16);
 const MAX_COLLATERAL_AMOUNT_HEX = TermsContractParameters.generateHexValueOfLength(23);
 const MAX_GRACE_PERIOD_IN_DAYS_HEX = TermsContractParameters.generateHexValueOfLength(2);
 
@@ -81,8 +85,8 @@ export class CollateralizedLoanTerms {
             throw new Error(CollateralizerAdapterErrors.INVALID_DECIMAL_VALUE());
         }
 
-        if (collateralAmount.isNegative()) {
-            throw new Error(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_IS_NEGATIVE());
+        if (collateralAmount.isNegative() || collateralAmount.isZero()) {
+            throw new Error(CollateralizerAdapterErrors.COLLATERAL_AMOUNT_MUST_BE_POSITIVE());
         }
 
         if (collateralAmount.gt(MAX_COLLATERAL_AMOUNT_HEX)) {


### PR DESCRIPTION
This PR introduces the following changes:

- Throw an error when `collateralAmount = 0` and a user tries filling / generating a loan
- Throw an error when `collateralTokenIndex` refers to an index not currently tracked by our token registry.