### PR TITLE
build: use dharma fork of web3

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
         "lodash.pickby": "^4.6.0",
         "lodash.values": "^4.3.0",
         "moment": "^2.20.1",
-        "web3": "~0.20.7",
+        "web3": "git+https://github.com/dharmaprotocol/web3.js.git",
         "single-line-string": "^0.0.2",
         "tiny-promisify": "^1.0.0",
         "typedoc-plugin-markdown": "^1.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8641,16 +8641,6 @@ web3-utils@1.0.0-beta.29:
     underscore "1.8.3"
     utf8 "2.1.1"
 
-web3@0.20.7:
-  version "0.20.7"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-0.20.7.tgz#1605e6d81399ed6f85a471a4f3da0c8be57df2f7"
-  dependencies:
-    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-    crypto-js "^3.1.4"
-    utf8 "^2.1.1"
-    xhr2-cookies "^1.1.0"
-    xmlhttprequest "*"
-
 web3@^0.18.4:
   version "0.18.4"
   resolved "https://registry.yarnpkg.com/web3/-/web3-0.18.4.tgz#81ec1784145491f2eaa8955b31c06049e07c5e7d"
@@ -8659,6 +8649,16 @@ web3@^0.18.4:
     crypto-js "^3.1.4"
     utf8 "^2.1.1"
     xhr2 "*"
+    xmlhttprequest "*"
+
+"web3@git+https://github.com/dharmaprotocol/web3.js.git":
+  version "0.20.7"
+  resolved "git+https://github.com/dharmaprotocol/web3.js.git#798e8b97dc38e58cce4cdd92957dc756dabac9d8"
+  dependencies:
+    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+    crypto-js "^3.1.4"
+    utf8 "^2.1.1"
+    xhr2-cookies "^1.1.0"
     xmlhttprequest "*"
 
 webidl-conversions@^4.0.2:


### PR DESCRIPTION
This branch uses a DharmaProtocol fork of web3 that uses a DharmaProtocol fork of the BigNumber fork that Web3 uses, and patches that fork to include the necessary `isBigNumber` function.

This is messy because everything underlying it is messy - from BigNumber to Web3. Hopefully it will be resolved in Web3 v 1.0, in which case we can scrap all of this.