### PR TITLE
feat: add origin snapshotting

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
         }
     },
     "jest": {
+        "globalSetup": "./dist/es/scripts/testSetup.js",
+        "globalTeardown": "./dist/es/scripts/testTeardown.js",
         "transform": {
             ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
         },

--- a/scripts/testSetup.ts
+++ b/scripts/testSetup.ts
@@ -1,0 +1,19 @@
+import * as Web3 from "web3";
+
+import { Web3Utils } from "../utils/web3_utils";
+
+const provider = new Web3.providers.HttpProvider("http://localhost:8545");
+const web3 = new Web3(provider);
+const web3Utils = new Web3Utils(web3);
+
+module.exports = async () => {
+    console.log("\n\n* Test Setup *\n");
+
+    const originSnapshot = await web3Utils.saveTestSnapshot();
+
+    process.env.originSnapshot = originSnapshot.toString();
+
+    console.log(`Saved origin snapshot with ID: ${originSnapshot}`);
+
+    console.log("\n\n* Test Setup Complete *\n");
+};

--- a/scripts/testTeardown.ts
+++ b/scripts/testTeardown.ts
@@ -1,0 +1,21 @@
+import * as Web3 from "web3";
+
+import { Web3Utils } from "../utils/web3_utils";
+
+const provider = new Web3.providers.HttpProvider("http://localhost:8545");
+const web3 = new Web3(provider);
+const web3Utils = new Web3Utils(web3);
+
+module.exports = async () => {
+    console.log("\n\n* Test Teardown *\n");
+
+    const originSnapshotString = process.env.originSnapshot;
+    const originSnapshot = parseInt(originSnapshotString, 10);
+
+    if (originSnapshotString && originSnapshot >= 0) {
+        await web3Utils.revertToSnapshot(originSnapshot);
+        console.log(`Reset blockchain to snapshot with ID: ${originSnapshot}`);
+    }
+
+    console.log("\n\n* Test Teardown Complete *\n");
+};


### PR DESCRIPTION
This outlines a way to do origin snapshotting, so that we can reset to an origin snapshot during test setup without needing to save snapshots, etc.

One thing I'm uncertain about is whether the script .ts files get transpiled on difference machines - because this needs to happen in order to work. Will look to circle to find out.